### PR TITLE
Fix/build

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -2,8 +2,13 @@ import { defineBuildConfig } from 'unbuild'
 
 export default defineBuildConfig({
     failOnWarn: false,
-    externals: ['fsevents', 'vite', '@vitejs/plugin-vue', '@nuxt/kit', '@nuxt/schema'],
-    entries: [
-        'src/nitro/fetch-capture',
+    externals: [
+        'fsevents',
+        'vite',
+        '@vitejs/plugin-vue',
+        '@nuxt/kit',
+        '@nuxt/schema',
+        '#imports', // Nuxt auto-imports alias, must be external
     ],
+    entries: ['src/nitro/fetch-capture'],
 })

--- a/client/src/stores/observatory.ts
+++ b/client/src/stores/observatory.ts
@@ -14,8 +14,6 @@
 
 import { ref, onUnmounted } from 'vue'
 
-const POLL_MS = 500
-
 export interface TransitionEntry {
     id: string
     transitionName: string
@@ -30,12 +28,70 @@ export interface TransitionEntry {
     mode?: string
 }
 
+export interface FetchEntry {
+    id: string
+    key: string
+    url: string
+    status: 'pending' | 'ok' | 'error' | 'cached'
+    origin: 'ssr' | 'csr'
+    ms?: number
+    size?: number
+    cached: boolean
+    payload?: unknown
+    file?: string
+    line?: number
+    startOffset?: number
+}
+
+interface ComposableEntry {
+    id: string
+    name: string
+    component: string
+    instances: number
+    status: 'mounted' | 'unmounted'
+    leak: boolean
+    leakReason?: string
+    refs: Array<{ key: string; type: string; val: string }>
+    watchers: number
+    intervals: number
+    lifecycle: { onMounted: boolean; onUnmounted: boolean; watchersCleaned: boolean; intervalsCleaned: boolean }
+}
+
+interface ProvideInjectNode {
+    id: string
+    label: string
+    type: 'provider' | 'consumer' | 'both' | 'error'
+    provides: Array<{ key: string; val: string; reactive: boolean }>
+    injects: Array<{ key: string; from: string | null; ok: boolean }>
+    children: ProvideInjectNode[]
+}
+
+interface RenderNode {
+    id: string
+    label: string
+    file: string
+    renders: number
+    avgMs: number
+    triggers: string[]
+    children: RenderNode[]
+}
+
 interface ObservatorySnapshot {
     transitions?: TransitionEntry[]
+    fetch?: FetchEntry[]
+    composables?: ComposableEntry[]
+    provideInject?: ProvideInjectNode[]
+    renders?: RenderNode[]
 }
+
+const POLL_MS = 500
 
 export function useObservatoryData() {
     const transitions = ref<TransitionEntry[]>([])
+    const fetches = ref<FetchEntry[]>([])
+    const composables = ref<ComposableEntry[]>([])
+    const provideInject = ref<ProvideInjectNode[]>([])
+    const renders = ref<RenderNode[]>([])
     const connected = ref(false)
 
     function request() {
@@ -47,8 +103,50 @@ export function useObservatoryData() {
             return
         }
 
-        const data = event.data.data as ObservatorySnapshot
-        transitions.value = data.transitions ?? []
+        let data: ObservatorySnapshot | null = null
+
+        if (typeof event.data.data === 'string') {
+            try {
+                data = JSON.parse(event.data.data)
+            } catch (err) {
+                console.warn('Failed to parse observatory snapshot:', err)
+
+                data = null
+            }
+        } else {
+            data = event.data.data as ObservatorySnapshot
+        }
+
+        transitions.value = data?.transitions ?? []
+        fetches.value = data?.fetch ?? []
+        composables.value = data?.composables ?? []
+
+        // Always guarantee provideInject.value is an array
+        const pi = data?.provideInject
+
+        if (Array.isArray(pi)) {
+            provideInject.value = pi
+        } else if (pi && typeof pi === 'object') {
+            // If registry returns { provides, injects }, build a single node
+            provideInject.value = [
+                {
+                    provides: Array.isArray(pi.provides) ? pi.provides : [],
+                    injects: Array.isArray(pi.injects) ? pi.injects : [],
+                    id: 'root',
+                    label: 'Provide/Inject Root',
+                    type: 'both',
+                    children: [],
+                },
+            ]
+        } else {
+            provideInject.value = []
+        }
+
+        if (!Array.isArray(provideInject.value)) {
+            provideInject.value = []
+        }
+
+        renders.value = data?.renders ?? []
         connected.value = true
     }
 
@@ -61,5 +159,5 @@ export function useObservatoryData() {
         clearInterval(timer)
     })
 
-    return { transitions, connected }
+    return { transitions, fetches, composables, provideInject, renders, connected }
 }

--- a/client/src/views/ComponentBlock.vue
+++ b/client/src/views/ComponentBlock.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+interface ComponentNode {
+    id: string
+    label: string
+    file: string
+    renders: number
+    avgMs: number
+    triggers: string[]
+    children: ComponentNode[]
+}
+
+const props = defineProps<{
+    node: ComponentNode
+    mode: string
+    threshold: number
+    hotOnly: boolean
+    selected?: string
+}>()
+
+const emit = defineEmits(['select'])
+
+function getVal(n: ComponentNode) {
+    return props.mode === 'count' ? n.renders : n.avgMs
+}
+
+function getMax(n: ComponentNode): number {
+    let max = 1
+
+    function walk(ns: ComponentNode[]) {
+        ns.forEach((n) => {
+            const v = getVal(n)
+
+            if (v > max) {
+                max = v
+            }
+
+            walk(n.children)
+        })
+    }
+
+    walk([n])
+
+    return Math.max(max, props.mode === 'count' ? 40 : 20)
+}
+
+function heatColor(val: number, max: number) {
+    const r = Math.min(val / max, 1)
+
+    if (r < 0.25) {
+        return { bg: '#EAF3DE', text: '#27500A', border: '#97C459' }
+    } else {
+        if (r < 0.55) {
+            return { bg: '#FAEEDA', text: '#633806', border: '#EF9F27' }
+        } else {
+            if (r < 0.8) {
+                return { bg: '#FAECE7', text: '#712B13', border: '#D85A30' }
+            } else {
+                return { bg: '#FCEBEB', text: '#791F1F', border: '#E24B4A' }
+            }
+        }
+    }
+}
+
+function isHotNode(n: ComponentNode) {
+    let value: number
+
+    if (props.mode === 'count') {
+        value = n.renders
+    } else {
+        value = n.avgMs
+    }
+
+    if (value >= props.threshold) {
+        return true
+    } else {
+        return false
+    }
+}
+
+function shouldShow(n: ComponentNode): boolean {
+    if (!props.hotOnly) {
+        return true
+    } else {
+        if (isHotNode(n)) {
+            return true
+        } else {
+            if (n.children.some(isHotNode)) {
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+}
+
+function handleSelect(n: ComponentNode) {
+    emit('select', n)
+}
+</script>
+
+<template>
+    <div
+        v-if="shouldShow(props.node)"
+        :style="{
+            background: heatColor(getVal(props.node), getMax(props.node)).bg,
+            border:
+                props.selected === props.node.id
+                    ? `2px solid ${heatColor(getVal(props.node), getMax(props.node)).border}`
+                    : `1px solid ${heatColor(getVal(props.node), getMax(props.node)).border}`,
+            borderRadius: '6px',
+            padding: '6px 9px',
+            marginBottom: '5px',
+            cursor: 'pointer',
+        }"
+        @click="handleSelect(props.node)"
+    >
+        <div style="display: flex; align-items: center; gap: 6px">
+            <span
+                :style="{
+                    fontFamily: 'var(--mono)',
+                    fontSize: '11px',
+                    fontWeight: 500,
+                    color: heatColor(getVal(props.node), getMax(props.node)).text,
+                }"
+            >
+                {{ props.node.label }}
+            </span>
+            <span
+                :style="{
+                    fontFamily: 'var(--mono)',
+                    fontSize: '10px',
+                    color: heatColor(getVal(props.node), getMax(props.node)).text,
+                    opacity: 0.7,
+                    marginLeft: 'auto',
+                }"
+            >
+                {{ props.mode === 'count' ? getVal(props.node) : getVal(props.node).toFixed(1) + 'ms' }}
+                {{ props.mode === 'count' ? 'renders' : 'ms avg' }}
+            </span>
+        </div>
+        <div
+            v-if="props.node.children && props.node.children.length"
+            :style="{
+                marginLeft: '10px',
+                borderLeft: `1.5px solid ${heatColor(getVal(props.node), getMax(props.node)).border}40`,
+                paddingLeft: '8px',
+                marginTop: '5px',
+            }"
+        >
+            <ComponentBlock
+                v-for="child in props.node.children"
+                :key="child.id"
+                :node="child"
+                :mode="props.mode"
+                :threshold="props.threshold"
+                :hot-only="props.hotOnly"
+                :selected="props.selected"
+                @select="handleSelect"
+            />
+        </div>
+    </div>
+</template>

--- a/client/src/views/ComposableTracker.vue
+++ b/client/src/views/ComposableTracker.vue
@@ -1,133 +1,57 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, type Ref } from 'vue'
+import { useObservatoryData } from '../stores/observatory'
 
-interface RefEntry {
-    key: string
-    type: string
-    val: string
-}
 interface ComposableEntry {
     id: string
     name: string
     component: string
     instances: number
-    status: 'mounted' | 'unmounted'
+    status: string
     leak: boolean
     leakReason?: string
-    refs: RefEntry[]
+    refs: Array<{ key: string; type: string; val: string }>
     watchers: number
     intervals: number
-    lifecycle: { onMounted: boolean; onUnmounted: boolean; watchersCleaned: boolean; intervalsCleaned: boolean }
+    lifecycle: {
+        onMounted: boolean
+        onUnmounted: boolean
+        watchersCleaned: boolean
+        intervalsCleaned: boolean
+    }
 }
 
-const entries = ref<ComposableEntry[]>([
-    {
-        id: '1',
-        name: 'useAuth',
-        component: 'App.vue',
-        instances: 1,
-        status: 'mounted',
-        leak: false,
-        refs: [
-            { key: 'user', type: 'ref', val: '{ id: "u_9x3k", role: "admin" }' },
-            { key: 'isLoggedIn', type: 'computed', val: 'true' },
-        ],
-        watchers: 1,
-        intervals: 0,
-        lifecycle: { onMounted: true, onUnmounted: true, watchersCleaned: true, intervalsCleaned: true },
-    },
-    {
-        id: '2',
-        name: 'useWebSocket',
-        component: 'Dashboard.vue',
-        instances: 1,
-        status: 'unmounted',
-        leak: true,
-        leakReason: 'socket.close() never called — 2 watchers still running after unmount',
-        refs: [
-            { key: 'socket', type: 'ref', val: 'WebSocket { readyState: 1 }' },
-            { key: 'messages', type: 'ref', val: 'Array(47)' },
-        ],
-        watchers: 2,
-        intervals: 0,
-        lifecycle: { onMounted: true, onUnmounted: false, watchersCleaned: false, intervalsCleaned: true },
-    },
-    {
-        id: '3',
-        name: 'usePoller',
-        component: 'StockTicker.vue',
-        instances: 2,
-        status: 'unmounted',
-        leak: true,
-        leakReason: 'setInterval #37 never cleared — still firing every 2000ms',
-        refs: [
-            { key: 'data', type: 'ref', val: '{ price: 142.5 }' },
-            { key: 'intervalId', type: 'ref', val: '37' },
-        ],
-        watchers: 0,
-        intervals: 1,
-        lifecycle: { onMounted: true, onUnmounted: false, watchersCleaned: true, intervalsCleaned: false },
-    },
-    {
-        id: '4',
-        name: 'useCart',
-        component: 'CartDrawer.vue',
-        instances: 1,
-        status: 'mounted',
-        leak: false,
-        refs: [
-            { key: 'items', type: 'ref', val: 'Array(3)' },
-            { key: 'total', type: 'computed', val: '248.50' },
-        ],
-        watchers: 0,
-        intervals: 0,
-        lifecycle: { onMounted: false, onUnmounted: false, watchersCleaned: true, intervalsCleaned: true },
-    },
-    {
-        id: '5',
-        name: 'useBreakpoint',
-        component: 'Layout.vue',
-        instances: 1,
-        status: 'mounted',
-        leak: false,
-        refs: [
-            { key: 'isMobile', type: 'computed', val: 'false' },
-            { key: 'width', type: 'ref', val: '1280' },
-        ],
-        watchers: 0,
-        intervals: 0,
-        lifecycle: { onMounted: true, onUnmounted: true, watchersCleaned: true, intervalsCleaned: true },
-    },
-    {
-        id: '6',
-        name: 'useIntersectionObserver',
-        component: 'LazyImage.vue',
-        instances: 4,
-        status: 'mounted',
-        leak: false,
-        refs: [{ key: 'isVisible', type: 'ref', val: 'true' }],
-        watchers: 0,
-        intervals: 0,
-        lifecycle: { onMounted: true, onUnmounted: true, watchersCleaned: true, intervalsCleaned: true },
-    },
-])
+const { composables } = useObservatoryData()
+const entries = composables as Ref<ComposableEntry[]>
 
 const filter = ref('all')
 const search = ref('')
 const expanded = ref<string | null>(null)
 
-const counts = computed(() => ({
-    mounted: entries.value.filter((e) => e.status === 'mounted').length,
-    leaks: entries.value.filter((e) => e.leak).length,
-}))
+const counts = computed<{ mounted: number; leaks: number }>(() => {
+    return {
+        mounted: entries.value.filter((e) => e.status === 'mounted').length,
+        leaks: entries.value.filter((e) => e.leak).length,
+    }
+})
 
-const filtered = computed(() => {
+const filtered = computed<ComposableEntry[]>(() => {
     return entries.value.filter((e) => {
-        if (filter.value === 'leak' && !e.leak) return false
-        if (filter.value === 'unmounted' && e.status !== 'unmounted') return false
-        const q = search.value.toLowerCase()
-        if (q && !e.name.toLowerCase().includes(q) && !e.component.toLowerCase().includes(q)) return false
-        return true
+        if (filter.value === 'leak' && !e.leak) {
+            return false
+        } else {
+            if (filter.value === 'unmounted' && e.status !== 'unmounted') {
+                return false
+            } else {
+                const q = search.value.toLowerCase()
+
+                if (q && !e.name.toLowerCase().includes(q) && !e.component.toLowerCase().includes(q)) {
+                    return false
+                } else {
+                    return true
+                }
+            }
+        }
     })
 })
 

--- a/client/src/views/FetchDashboard.vue
+++ b/client/src/views/FetchDashboard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useObservatoryData } from '../stores/observatory'
 
 interface FetchEntry {
     id: string
@@ -16,126 +17,21 @@ interface FetchEntry {
     startOffset?: number
 }
 
-// Mock data — in production this comes from the WS registry
-const entries = ref<FetchEntry[]>([
-    {
-        id: '1',
-        key: 'product-detail',
-        url: '/api/products/42',
-        status: 'ok',
-        origin: 'ssr',
-        ms: 48,
-        size: 3276,
-        cached: false,
-        startOffset: 0,
-        file: 'pages/products/[id].vue',
-        line: 8,
-    },
-    {
-        id: '2',
-        key: 'related-products',
-        url: '/api/products?related=42',
-        status: 'ok',
-        origin: 'ssr',
-        ms: 112,
-        size: 19148,
-        cached: false,
-        startOffset: 10,
-        file: 'pages/products/[id].vue',
-        line: 14,
-    },
-    {
-        id: '3',
-        key: 'user-session',
-        url: '/api/auth/session',
-        status: 'cached',
-        origin: 'csr',
-        ms: 0,
-        size: 819,
-        cached: true,
-        startOffset: 0,
-        file: 'layouts/default.vue',
-        line: 5,
-    },
-    {
-        id: '4',
-        key: 'cart-summary',
-        url: '/api/cart',
-        status: 'ok',
-        origin: 'csr',
-        ms: 67,
-        size: 2150,
-        cached: false,
-        startOffset: 5,
-        file: 'components/CartDrawer.vue',
-        line: 3,
-    },
-    {
-        id: '5',
-        key: 'product-reviews',
-        url: '/api/products/42/reviews',
-        status: 'pending',
-        origin: 'csr',
-        ms: undefined,
-        size: undefined,
-        cached: false,
-        startOffset: 120,
-        file: 'components/ReviewList.vue',
-        line: 6,
-    },
-    {
-        id: '6',
-        key: 'recommendations',
-        url: '/api/recommend?u=u_9x3k',
-        status: 'ok',
-        origin: 'csr',
-        ms: 201,
-        size: 9626,
-        cached: false,
-        startOffset: 30,
-        file: 'components/Recommendations.vue',
-        line: 4,
-    },
-    {
-        id: '7',
-        key: 'inventory-check',
-        url: '/api/inventory/42',
-        status: 'error',
-        origin: 'csr',
-        ms: 503,
-        size: undefined,
-        cached: false,
-        startOffset: 55,
-        file: 'components/StockBadge.vue',
-        line: 7,
-    },
-    {
-        id: '8',
-        key: 'nav-links',
-        url: '/api/nav',
-        status: 'cached',
-        origin: 'ssr',
-        ms: 0,
-        size: 1126,
-        cached: true,
-        startOffset: 0,
-        file: 'layouts/default.vue',
-        line: 9,
-    },
-])
+// Use live fetch data from the Nuxt registry bridge
+const { fetches: entries } = useObservatoryData()
 
 const filter = ref<string>('all')
 const search = ref('')
 const selected = ref<FetchEntry | null>(null)
 
 const counts = computed(() => ({
-    ok: entries.value.filter((e) => e.status === 'ok').length,
-    pending: entries.value.filter((e) => e.status === 'pending').length,
-    error: entries.value.filter((e) => e.status === 'error').length,
+    ok: entries.value?.filter((e) => e.status === 'ok').length ?? 0,
+    pending: entries.value?.filter((e) => e.status === 'pending').length ?? 0,
+    error: entries.value?.filter((e) => e.status === 'error').length ?? 0,
 }))
 
 const filtered = computed(() => {
-    return entries.value.filter((e) => {
+    return (entries.value ?? []).filter((e) => {
         if (filter.value !== 'all' && e.status !== filter.value) return false
         const q = search.value.toLowerCase()
         if (q && !e.key.includes(q) && !e.url.includes(q)) return false
@@ -176,16 +72,16 @@ function barColor(s: string) {
 }
 
 function barWidth(e: FetchEntry) {
-    const maxMs = Math.max(...entries.value.filter((x) => x.ms).map((x) => x.ms!), 1)
+    const maxMs = Math.max(...(entries.value ?? []).filter((x) => x.ms).map((x) => x.ms!), 1)
     return e.ms != null ? Math.max(4, Math.round((e.ms / maxMs) * 100)) : 4
 }
 
 function wfLeft(e: FetchEntry) {
-    const maxEnd = Math.max(...entries.value.map((x) => (x.startOffset ?? 0) + (x.ms ?? 0)), 1)
+    const maxEnd = Math.max(...(entries.value ?? []).map((x) => (x.startOffset ?? 0) + (x.ms ?? 0)), 1)
     return Math.round(((e.startOffset ?? 0) / maxEnd) * 100)
 }
 function wfWidth(e: FetchEntry) {
-    const maxEnd = Math.max(...entries.value.map((x) => (x.startOffset ?? 0) + (x.ms ?? 0)), 1)
+    const maxEnd = Math.max(...(entries.value ?? []).map((x) => (x.startOffset ?? 0) + (x.ms ?? 0)), 1)
     return e.ms != null ? Math.round((e.ms / maxEnd) * 100) : 2
 }
 
@@ -195,18 +91,12 @@ function formatSize(bytes: number) {
 }
 
 function replayFetch() {
-    if (!selected.value) return
-    const e = selected.value
-    e.status = 'pending'
-    e.ms = undefined
-    setTimeout(() => {
-        e.status = 'ok'
-        e.ms = Math.floor(Math.random() * 150 + 20)
-    }, 700)
+    // No-op: cannot replay fetch from devtools UI (see Nuxt docs)
+    // You should call the original refresh() from useFetch in-app, not here
 }
 
 function clearAll() {
-    entries.value = []
+    // No-op: cannot clear live registry from client
     selected.value = null
 }
 </script>

--- a/client/src/views/ProvideInjectGraph.vue
+++ b/client/src/views/ProvideInjectGraph.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useObservatoryData } from '../stores/observatory'
 
 interface TreeNodeData {
     id: string
@@ -31,15 +32,30 @@ const V_GAP = 72
 const H_GAP = 18
 
 function nodeColor(n: TreeNodeData): string {
-    if (n.injects.some((i) => !i.ok)) return 'var(--red)'
-    if (n.type === 'both') return 'var(--blue)'
-    if (n.type === 'provider') return 'var(--teal)'
+    if (n.injects.some((i) => !i.ok)) {
+        return 'var(--red)'
+    }
+
+    if (n.type === 'both') {
+        return 'var(--blue)'
+    }
+
+    if (n.type === 'provider') {
+        return 'var(--teal)'
+    }
+
     return 'var(--text3)'
 }
 
 function matchesFilter(n: TreeNodeData, filter: string): boolean {
-    if (filter === 'all') return true
-    if (filter === 'warn') return n.injects.some((i) => !i.ok)
+    if (filter === 'all') {
+        return true
+    }
+
+    if (filter === 'warn') {
+        return n.injects.some((i) => !i.ok)
+    }
+
     return n.provides.some((p) => p.key === filter) || n.injects.some((i) => i.key === filter)
 }
 
@@ -47,79 +63,8 @@ function countLeaves(n: TreeNodeData): number {
     return n.children.length === 0 ? 1 : n.children.reduce((s, c) => s + countLeaves(c), 0)
 }
 
-const nodes = ref<TreeNodeData[]>([
-    {
-        id: 'App',
-        label: 'App.vue',
-        type: 'provider',
-        provides: [
-            { key: 'authContext', val: '{ user, logout }', reactive: true },
-            { key: 'theme', val: '"dark"', reactive: false },
-        ],
-        injects: [],
-        children: [
-            {
-                id: 'Layout',
-                label: 'Layout.vue',
-                type: 'both',
-                provides: [{ key: 'routerState', val: 'useRoute()', reactive: true }],
-                injects: [{ key: 'theme', from: 'App.vue', ok: true }],
-                children: [
-                    {
-                        id: 'Sidebar',
-                        label: 'Sidebar.vue',
-                        type: 'consumer',
-                        provides: [],
-                        injects: [
-                            { key: 'authContext', from: 'App.vue', ok: true },
-                            { key: 'theme', from: 'App.vue', ok: true },
-                        ],
-                        children: [],
-                    },
-                    {
-                        id: 'NavBar',
-                        label: 'NavBar.vue',
-                        type: 'consumer',
-                        provides: [],
-                        injects: [
-                            { key: 'authContext', from: 'App.vue', ok: true },
-                            { key: 'routerState', from: 'Layout.vue', ok: true },
-                        ],
-                        children: [],
-                    },
-                    {
-                        id: 'ProductList',
-                        label: 'ProductList.vue',
-                        type: 'error',
-                        provides: [],
-                        injects: [
-                            { key: 'cartContext', from: null, ok: false },
-                            { key: 'theme', from: 'App.vue', ok: true },
-                        ],
-                        children: [
-                            {
-                                id: 'ProductCard',
-                                label: 'ProductCard.vue',
-                                type: 'error',
-                                provides: [],
-                                injects: [{ key: 'cartContext', from: null, ok: false }],
-                                children: [],
-                            },
-                        ],
-                    },
-                    {
-                        id: 'UserMenu',
-                        label: 'UserMenu.vue',
-                        type: 'consumer',
-                        provides: [],
-                        injects: [{ key: 'authContext', from: 'App.vue', ok: true }],
-                        children: [],
-                    },
-                ],
-            },
-        ],
-    },
-])
+const { provideInject } = useObservatoryData()
+const nodes = provideInject
 
 const activeFilter = ref('all')
 const selectedNode = ref<TreeNodeData | null>(null)
@@ -147,13 +92,16 @@ const layout = computed<LayoutNode[]>(() => {
     function place(node: TreeNodeData, depth: number, slotLeft: number, parentId: string | null) {
         const leaves = countLeaves(node)
         const slotW = leaves * (NODE_W + H_GAP) - H_GAP
+
         flat.push({
             data: node,
             parentId,
             x: Math.round(slotLeft + slotW / 2),
             y: Math.round(pad + depth * (NODE_H + V_GAP) + NODE_H / 2),
         })
+
         let childLeft = slotLeft
+
         for (const child of node.children) {
             const cl = countLeaves(child)
             place(child, depth + 1, childLeft, node.id)
@@ -162,6 +110,7 @@ const layout = computed<LayoutNode[]>(() => {
     }
 
     let left = pad
+
     for (const root of nodes.value) {
         const leaves = countLeaves(root)
         place(root, 0, left, null)
@@ -177,6 +126,7 @@ const canvasH = computed(() => layout.value.reduce((m, n) => Math.max(m, n.y + N
 
 const edges = computed<Edge[]>(() => {
     const byId = new Map(layout.value.map((n) => [n.data.id, n]))
+
     return layout.value
         .filter((n) => n.parentId !== null)
         .map((n) => {

--- a/client/src/views/RenderHeatmap.vue
+++ b/client/src/views/RenderHeatmap.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-import { ref, computed, defineComponent, h, onUnmounted, type VNode } from 'vue'
+import { ref, computed, onUnmounted } from 'vue'
+import ComponentBlock from './ComponentBlock.vue'
+import { useObservatoryData } from '../stores/observatory'
 
 interface ComponentNode {
     id: string
@@ -11,212 +13,16 @@ interface ComponentNode {
     children: ComponentNode[]
 }
 
-// ComponentBlock — recursive inline component
-const ComponentBlock = defineComponent({
-    name: 'ComponentBlock',
-    props: {
-        node: Object as () => ComponentNode,
-        mode: String,
-        threshold: Number,
-        hotOnly: Boolean,
-        selected: String,
-    },
-    emits: ['select'],
-    setup(props, { emit }): () => VNode | null {
-        function getVal(n: ComponentNode) {
-            return props.mode === 'count' ? n.renders : n.avgMs
-        }
+const { renders } = useObservatoryData()
+const baseNodes = renders
 
-        function getMax(): number {
-            let max = 1
-
-            function walk(ns: ComponentNode[]) {
-                ns.forEach((n) => {
-                    const v = getVal(n)
-
-                    if (v > max) {
-                        max = v
-                    }
-
-                    walk(n.children)
-                })
-            }
-
-            walk([props.node!])
-
-            return Math.max(max, props.mode === 'count' ? 40 : 20)
-        }
-        function heatColor(val: number, max: number) {
-            const r = Math.min(val / max, 1)
-
-            if (r < 0.25) {
-                return { bg: '#EAF3DE', text: '#27500A', border: '#97C459' }
-            }
-
-            if (r < 0.55) {
-                return { bg: '#FAEEDA', text: '#633806', border: '#EF9F27' }
-            }
-
-            if (r < 0.8) {
-                return { bg: '#FAECE7', text: '#712B13', border: '#D85A30' }
-            }
-
-            return { bg: '#FCEBEB', text: '#791F1F', border: '#E24B4A' }
-        }
-        function isHot(n: ComponentNode) {
-            return (props.mode === 'count' ? n.renders : n.avgMs) >= props.threshold!
-        }
-
-        return () => {
-            const n = props.node!
-
-            if (props.hotOnly && !isHot(n) && !n.children.some((c) => (props.mode === 'count' ? c.renders : c.avgMs) >= props.threshold!)) {
-                return null
-            }
-
-            const max = getMax()
-            const val = getVal(n)
-            const col = heatColor(val, max)
-            const isSel = props.selected === n.id
-            const unit = props.mode === 'count' ? 'renders' : 'ms avg'
-            const valStr = props.mode === 'count' ? String(val) : val.toFixed(1) + 'ms'
-
-            return h(
-                'div',
-                {
-                    style: {
-                        background: col.bg,
-                        border: isSel ? `2px solid ${col.border}` : `1px solid ${col.border}`,
-                        borderRadius: '6px',
-                        padding: '6px 9px',
-                        marginBottom: '5px',
-                        cursor: 'pointer',
-                    },
-                    onClick: () => emit('select', n),
-                },
-                [
-                    h('div', { style: { display: 'flex', alignItems: 'center', gap: '6px' } }, [
-                        h('span', { style: { fontFamily: 'var(--mono)', fontSize: '11px', fontWeight: '500', color: col.text } }, n.label),
-                        h(
-                            'span',
-                            { style: { fontFamily: 'var(--mono)', fontSize: '10px', color: col.text, opacity: '0.7', marginLeft: 'auto' } },
-                            `${valStr} ${unit}`
-                        ),
-                    ]),
-                    n.children.length
-                        ? h(
-                              'div',
-                              {
-                                  style: {
-                                      marginLeft: '10px',
-                                      borderLeft: `1.5px solid ${col.border}40`,
-                                      paddingLeft: '8px',
-                                      marginTop: '5px',
-                                  },
-                              },
-                              n.children.map((child) =>
-                                  h(ComponentBlock, {
-                                      node: child,
-                                      mode: props.mode,
-                                      threshold: props.threshold,
-                                      hotOnly: props.hotOnly,
-                                      selected: props.selected,
-                                      onSelect: (v: ComponentNode) => emit('select', v),
-                                  })
-                              )
-                          )
-                        : null,
-                ]
-            )
-        }
-    },
-})
-
-// Mock data
-const baseNodes = ref<ComponentNode[]>([
-    {
-        id: 'NavBar',
-        label: 'NavBar.vue',
-        file: 'components/NavBar.vue',
-        renders: 3,
-        avgMs: 1.2,
-        triggers: ['props.user changed'],
-        children: [],
-    },
-    {
-        id: 'Sidebar',
-        label: 'Sidebar.vue',
-        file: 'components/Sidebar.vue',
-        renders: 2,
-        avgMs: 0.8,
-        triggers: ['parent re-render'],
-        children: [],
-    },
-    {
-        id: 'ProductGrid',
-        label: 'ProductGrid.vue',
-        file: 'components/ProductGrid.vue',
-        renders: 18,
-        avgMs: 14.3,
-        triggers: ['store: products updated', 'props.filter changed', 'parent re-render (×16)'],
-        children: [
-            {
-                id: 'ProductCard',
-                label: 'ProductCard.vue ×12',
-                file: 'components/ProductCard.vue',
-                renders: 24,
-                avgMs: 3.1,
-                triggers: ['parent re-render (×24)'],
-                children: [],
-            },
-            {
-                id: 'PriceTag',
-                label: 'PriceTag.vue ×12',
-                file: 'components/PriceTag.vue',
-                renders: 36,
-                avgMs: 0.4,
-                triggers: ['props.price changed (×36)'],
-                children: [],
-            },
-        ],
-    },
-    {
-        id: 'CartSummary',
-        label: 'CartSummary.vue',
-        file: 'components/CartSummary.vue',
-        renders: 9,
-        avgMs: 5.7,
-        triggers: ['store: cart updated (×9)'],
-        children: [
-            {
-                id: 'CartItem',
-                label: 'CartItem.vue ×3',
-                file: 'components/CartItem.vue',
-                renders: 12,
-                avgMs: 1.8,
-                triggers: ['parent re-render (×12)'],
-                children: [],
-            },
-        ],
-    },
-    {
-        id: 'FilterBar',
-        label: 'FilterBar.vue',
-        file: 'components/FilterBar.vue',
-        renders: 7,
-        avgMs: 2.1,
-        triggers: ['store: filters changed (×7)'],
-        children: [],
-    },
-    { id: 'Footer', label: 'Footer.vue', file: 'components/Footer.vue', renders: 1, avgMs: 0.3, triggers: ['initial mount'], children: [] },
-])
+let liveInterval: ReturnType<typeof setInterval> | undefined
 
 const activeMode = ref<'count' | 'time'>('count')
 const activeThreshold = ref(5)
 const activeHotOnly = ref(false)
 const frozen = ref(false)
 const activeSelected = ref<ComponentNode | null>(null)
-let liveInterval: ReturnType<typeof setInterval> | null = null
 
 const rootNodes = computed(() => baseNodes.value)
 
@@ -251,6 +57,10 @@ function isHot(n: ComponentNode) {
     return (activeMode.value === 'count' ? n.renders : n.avgMs) >= activeThreshold.value
 }
 
+function toggleFreeze() {
+    frozen.value = !frozen.value
+}
+
 function startLive() {
     liveInterval = setInterval(() => {
         if (frozen.value) {
@@ -263,13 +73,11 @@ function startLive() {
     }, 1800)
 }
 
-function toggleFreeze() {
-    frozen.value = !frozen.value
-}
-
 startLive()
 onUnmounted(() => {
-    if (liveInterval) clearInterval(liveInterval)
+    if (liveInterval) {
+        clearInterval(liveInterval)
+    }
 })
 </script>
 

--- a/client/src/views/TransitionTimeline.vue
+++ b/client/src/views/TransitionTimeline.vue
@@ -61,7 +61,7 @@ const timelineGeometry = computed(() => {
     }))
 })
 
-function phaseColor(phase: TransitionEntry['phase'], direction: TransitionEntry['direction']): string {
+function phaseColor(phase: TransitionEntry['phase']): string {
     if (phase === 'entering' || phase === 'leaving') {
         return '#7f77dd'
     }
@@ -204,7 +204,7 @@ function directionColor(e: TransitionEntry): string {
                                         :style="{
                                             left: timelineGeometry[i]?.left + '%',
                                             width: Math.max(timelineGeometry[i]?.width ?? 1, 1) + '%',
-                                            background: phaseColor(entry.phase, entry.direction),
+                                            background: phaseColor(entry.phase),
                                             opacity: entry.phase === 'entering' || entry.phase === 'leaving' ? '0.55' : '1',
                                         }"
                                     />
@@ -267,7 +267,13 @@ function directionColor(e: TransitionEntry): string {
                         <div class="panel-row">
                             <span class="panel-key">Duration</span>
                             <span class="panel-val mono" style="font-weight: 500">
-                                {{ selected.durationMs !== undefined ? selected.durationMs + 'ms' : selected.phase === 'interrupted' ? 'interrupted' : 'in progress' }}
+                                {{
+                                    selected.durationMs !== undefined
+                                        ? selected.durationMs + 'ms'
+                                        : selected.phase === 'interrupted'
+                                          ? 'interrupted'
+                                          : 'in progress'
+                                }}
                             </span>
                         </div>
                     </div>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nuxt-devtools-observatory",
     "version": "0.1.6",
-    "description": "Vue/Nuxt DevTools: useFetch Dashboard, provide/inject Graph, Composable Tracker, Render Heatmap",
+    "description": "Nuxt DevTools: useFetch Dashboard, provide/inject Graph, Composable Tracker, Render Heatmap",
     "type": "module",
     "main": "./dist/module.mjs",
     "module": "./dist/module.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nuxt-devtools-observatory",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "description": "Vue/Nuxt DevTools: useFetch Dashboard, provide/inject Graph, Composable Tracker, Render Heatmap",
     "type": "module",
     "main": "./dist/module.mjs",

--- a/playground/components/transitions/InterruptedTransition.vue
+++ b/playground/components/transitions/InterruptedTransition.vue
@@ -66,7 +66,9 @@ async function startAndInterrupt() {
 
 <style scoped>
 .slow-enter-enter-active {
-    transition: opacity 1.5s ease, transform 1.5s ease;
+    transition:
+        opacity 1.5s ease,
+        transform 1.5s ease;
 }
 
 .slow-enter-enter-from {

--- a/src/nitro/fetch-capture.ts
+++ b/src/nitro/fetch-capture.ts
@@ -1,19 +1,22 @@
-
 import { defineNitroPlugin } from '#imports'
 // Nitro plugin: captures server-side $fetch calls and annotates
 // responses with cache status headers for the client to detect.
 
 export default defineNitroPlugin((nitroApp) => {
+    // Define a type for the event object that allows attaching __ssrFetchStart
+    type EventWithSSRFetchStart = { [key: string]: unknown; __ssrFetchStart?: number }
+
     // Hook into h3 event responses to inject cache header
-    nitroApp.hooks.hook('request', (event) => {
+    nitroApp.hooks.hook('request', (event: EventWithSSRFetchStart) => {
         const originalFetch = globalThis.$fetch
 
         // Wrap $fetch on each request to capture SSR timing
-        ;(event as any).__ssrFetchStart = performance.now()
+        event.__ssrFetchStart = performance.now()
     })
 
-    nitroApp.hooks.hook('afterResponse', (event, response) => {
-        const start = (event as any).__ssrFetchStart
+    nitroApp.hooks.hook('afterResponse', (event: EventWithSSRFetchStart, response) => {
+        const start = event.__ssrFetchStart
+
         if (start && response) {
             const ms = Math.round(performance.now() - start)
             // Attach timing to response headers for client devtools to read

--- a/src/runtime/composables/composable-registry.ts
+++ b/src/runtime/composables/composable-registry.ts
@@ -49,8 +49,53 @@ export function setupComposableRegistry() {
         emit('composable:update', updated)
     }
 
+    function safeValue(val: unknown): unknown {
+        if (val === undefined || val === null) {
+            return val
+        }
+
+        if (typeof val === 'function') {
+            return undefined
+        }
+
+        if (typeof val === 'object') {
+            try {
+                return JSON.parse(JSON.stringify(val))
+            } catch {
+                return String(val)
+            }
+        }
+
+        return val
+    }
+
+    function sanitize(entry: ComposableEntry): ComposableEntry {
+        return {
+            id: entry.id,
+            name: entry.name,
+            componentFile: entry.componentFile,
+            componentUid: entry.componentUid,
+            status: entry.status,
+            leak: entry.leak,
+            leakReason: entry.leakReason,
+            refs: Object.fromEntries(
+                Object.entries(entry.refs).map(([k, v]) => [
+                    k,
+                    {
+                        type: v.type,
+                        value: safeValue(typeof v.value === 'object' && v.value !== null && 'value' in v.value ? v.value.value : v.value),
+                    },
+                ])
+            ),
+            watcherCount: entry.watcherCount,
+            intervalCount: entry.intervalCount,
+            lifecycle: entry.lifecycle,
+            file: entry.file,
+            line: entry.line,
+        }
+    }
     function getAll(): ComposableEntry[] {
-        return [...entries.value.values()]
+        return [...entries.value.values()].map(sanitize)
     }
 
     function emit(event: string, data: unknown) {

--- a/src/runtime/composables/fetch-registry.ts
+++ b/src/runtime/composables/fetch-registry.ts
@@ -67,65 +67,115 @@ export function setupFetchRegistry() {
 // ── Dev shim called by the Vite transform ─────────────────────────────────
 // This function is injected at call sites: __devFetch(url, opts, meta)
 export function __devFetch(
-    originalFn: (url: string, opts: Record<string, unknown>) => Promise<unknown>,
-    url: string,
-    opts: Record<string, unknown>,
+    originalFn: (...args: unknown[]) => unknown,
+    arg1: ((...args: unknown[]) => unknown) | string,
+    arg2: Record<string, unknown>,
     meta: { key: string; file: string; line: number }
 ) {
     if (!import.meta.dev || !import.meta.client) {
-        return originalFn(url, opts)
+        // Pass through for all signatures
+        return typeof arg1 === 'function' ? originalFn(arg1, arg2) : originalFn(arg1, arg2)
     }
 
     const registry = (window as Window & { __observatory__?: { fetch?: ReturnType<typeof setupFetchRegistry> } }).__observatory__?.fetch
 
     if (!registry) {
-        return originalFn(url, opts)
+        return typeof arg1 === 'function' ? originalFn(arg1, arg2) : originalFn(arg1, arg2)
     }
 
-    const id = `${meta.key}::${Date.now()}`
-    const startTime = performance.now()
-    const origin: 'ssr' | 'csr' = import.meta.server ? 'ssr' : 'csr'
+    // Detect useAsyncData signature: first arg is a function (handler)
+    if (typeof arg1 === 'function') {
+        // useAsyncData(handler, opts, meta)
+        const handler = arg1 as (...args: unknown[]) => unknown
+        // const opts = arg2 || {} // not used in this branch
 
-    registry.register({
-        id,
-        key: meta.key,
-        url: typeof url === 'string' ? url : String(url),
-        status: 'pending',
-        origin,
-        startTime,
-        cached: false,
-        file: meta.file,
-        line: meta.line,
-    })
-
-    return originalFn(url, {
-        ...opts,
-        onResponse({ response }: { response: Response }) {
-            const ms = Math.round(performance.now() - startTime)
-            const size = Number(response.headers?.get('content-length')) || undefined
-            const cached = response.headers?.get('x-nuxt-cache') === 'HIT'
-            registry.update(id, {
-                status: response.ok ? 'ok' : 'error',
-                endTime: performance.now(),
-                ms,
-                size,
-                cached,
+        return function wrappedHandler(...handlerArgs: unknown[]): Promise<unknown> {
+            const id = `${meta.key}::${Date.now()}`
+            const startTime = performance.now()
+            const origin: 'ssr' | 'csr' = import.meta.server ? 'ssr' : 'csr'
+            registry.register({
+                id,
+                key: meta.key,
+                url: meta.key, // No URL in useAsyncData, use key as identifier
+                status: 'pending',
+                origin,
+                startTime,
+                cached: false,
+                file: meta.file,
+                line: meta.line,
             })
 
-            if (typeof opts.onResponse === 'function') {
-                opts.onResponse({ response })
-            }
-        },
-        onResponseError({ response }: { response: Response }) {
-            registry.update(id, {
-                status: 'error',
-                endTime: performance.now(),
-                ms: Math.round(performance.now() - startTime),
-            })
+            // Call the original handler and track result
+            return Promise.resolve(handler(...handlerArgs))
+                .then((result: unknown) => {
+                    registry.update(id, {
+                        status: 'ok',
+                        endTime: performance.now(),
+                        ms: Math.round(performance.now() - startTime),
+                        payload: result,
+                    })
 
-            if (typeof opts.onResponseError === 'function') {
-                opts.onResponseError({ response })
-            }
-        },
-    })
+                    return result
+                })
+                .catch((error: unknown) => {
+                    registry.update(id, {
+                        status: 'error',
+                        endTime: performance.now(),
+                        ms: Math.round(performance.now() - startTime),
+                        error,
+                    })
+
+                    throw error
+                })
+        }
+    } else {
+        // useFetch(url, opts, meta)
+        const url = arg1 as string
+        const opts = arg2 || {}
+        const id = `${meta.key}::${Date.now()}`
+        const startTime = performance.now()
+        const origin: 'ssr' | 'csr' = import.meta.server ? 'ssr' : 'csr'
+        registry.register({
+            id,
+            key: meta.key,
+            url: typeof url === 'string' ? url : String(url),
+            status: 'pending',
+            origin,
+            startTime,
+            cached: false,
+            file: meta.file,
+            line: meta.line,
+        })
+
+        return originalFn(url, {
+            ...opts,
+            onResponse({ response }: { response: Response }) {
+                const ms = Math.round(performance.now() - startTime)
+                const size = Number(response.headers?.get('content-length')) || undefined
+                const cached = response.headers?.get('x-nuxt-cache') === 'HIT'
+                registry.update(id, {
+                    status: response.ok ? 'ok' : 'error',
+                    endTime: performance.now(),
+                    ms,
+                    size,
+                    cached,
+                })
+
+                if (typeof opts.onResponse === 'function') {
+                    opts.onResponse({ response })
+                }
+            },
+            onResponseError({ response }: { response: Response }) {
+                registry.update(id, {
+                    status: 'error',
+                    endTime: performance.now(),
+                    ms: Math.round(performance.now() - startTime),
+                })
+
+                if (typeof opts.onResponseError === 'function') {
+                    opts.onResponseError({ response })
+                }
+            },
+        })
+    }
 }

--- a/src/runtime/composables/fetch-registry.ts
+++ b/src/runtime/composables/fetch-registry.ts
@@ -42,8 +42,48 @@ export function setupFetchRegistry() {
         emit('fetch:update', updated)
     }
 
+    function safeValue(val: unknown): unknown {
+        // Try to JSON.stringify, fallback to string or undefined
+        if (val === undefined || val === null) {
+            return val
+        }
+
+        if (typeof val === 'function') {
+            return undefined
+        }
+
+        if (typeof val === 'object') {
+            try {
+                return JSON.parse(JSON.stringify(val))
+            } catch {
+                return String(val)
+            }
+        }
+
+        return val
+    }
+
+    function sanitize(entry: FetchEntry): FetchEntry {
+        return {
+            id: entry.id,
+            key: entry.key,
+            url: entry.url,
+            status: entry.status,
+            origin: entry.origin,
+            startTime: entry.startTime,
+            endTime: entry.endTime,
+            ms: entry.ms,
+            size: entry.size,
+            cached: entry.cached,
+            payload: safeValue(entry.payload),
+            error: safeValue(entry.error),
+            file: entry.file,
+            line: entry.line,
+        }
+    }
+
     function getAll(): FetchEntry[] {
-        return [...entries.value.values()]
+        return [...entries.value.values()].map(sanitize)
     }
 
     function clear() {

--- a/src/runtime/composables/provide-inject-registry.ts
+++ b/src/runtime/composables/provide-inject-registry.ts
@@ -40,8 +40,56 @@ export function setupProvideInjectRegistry() {
         emit('inject:register', entry)
     }
 
+    function safeValue(val: unknown): unknown {
+        if (val === undefined || val === null) {
+            return val
+        }
+
+        if (typeof val === 'function') {
+            return undefined
+        }
+
+        if (typeof val === 'object') {
+            try {
+                return JSON.parse(JSON.stringify(val))
+            } catch {
+                return String(val)
+            }
+        }
+
+        return val
+    }
+
+    function sanitizeProvide(entry: ProvideEntry): ProvideEntry {
+        return {
+            key: entry.key,
+            componentName: entry.componentName,
+            componentFile: entry.componentFile,
+            componentUid: entry.componentUid,
+            isReactive: entry.isReactive,
+            valueSnapshot: safeValue(entry.valueSnapshot),
+            line: entry.line,
+        }
+    }
+
+    function sanitizeInject(entry: InjectEntry): InjectEntry {
+        return {
+            key: entry.key,
+            componentName: entry.componentName,
+            componentFile: entry.componentFile,
+            componentUid: entry.componentUid,
+            resolved: entry.resolved,
+            resolvedFromFile: entry.resolvedFromFile,
+            resolvedFromUid: entry.resolvedFromUid,
+            line: entry.line,
+        }
+    }
+
     function getAll() {
-        return { provides: provides.value, injects: injects.value }
+        return {
+            provides: provides.value.map(sanitizeProvide),
+            injects: injects.value.map(sanitizeInject),
+        }
     }
 
     function emit(event: string, data: unknown) {
@@ -58,7 +106,6 @@ export function setupProvideInjectRegistry() {
 }
 
 // ── Dev shims called by Vite transform ────────────────────────────────────
-
 export function __devProvide(key: string | symbol, value: unknown, meta: { file: string; line: number }) {
     provide(key, value)
 

--- a/src/runtime/composables/render-registry.ts
+++ b/src/runtime/composables/render-registry.ts
@@ -99,8 +99,31 @@ export function setupRenderRegistry(nuxtApp: { vueApp: import('vue').App }, thre
         }
     }
 
+    function sanitize(entry: RenderEntry): RenderEntry {
+        return {
+            uid: entry.uid,
+            name: entry.name,
+            file: entry.file,
+            renders: entry.renders,
+            totalMs: entry.totalMs,
+            avgMs: entry.avgMs,
+            triggers: entry.triggers,
+            rect: entry.rect
+                ? {
+                      x: entry.rect.x,
+                      y: entry.rect.y,
+                      width: entry.rect.width,
+                      height: entry.rect.height,
+                      top: entry.rect.top,
+                      left: entry.rect.left,
+                  }
+                : undefined,
+            children: entry.children,
+            parentUid: entry.parentUid,
+        }
+    }
     function getAll(): RenderEntry[] {
-        return [...entries.value.values()].filter((e) => e.renders >= threshold)
+        return [...entries.value.values()].filter((e) => e.renders >= threshold).map(sanitize)
     }
 
     function snapshot(): RenderEntry[] {

--- a/src/runtime/composables/transition-registry.ts
+++ b/src/runtime/composables/transition-registry.ts
@@ -40,8 +40,21 @@ export function setupTransitionRegistry() {
         emit('transition:update', updated)
     }
 
+    function sanitize(entry: TransitionEntry): TransitionEntry {
+        const clone = { ...entry }
+
+        // Remove any function properties
+        for (const key in clone) {
+            if (typeof clone[key] === 'function') {
+                delete clone[key]
+            }
+        }
+
+        return clone
+    }
+
     function getAll(): TransitionEntry[] {
-        return [...entries.value.values()].map((e) => ({ ...e }))
+        return [...entries.value.values()].map(sanitize)
     }
 
     function emit(event: string, data: unknown) {
@@ -58,7 +71,6 @@ export function setupTransitionRegistry() {
 }
 
 // ── Tracked <Transition> wrapper ─────────────────────────────────────────
-
 type ElementHook = ((el: Element) => void) | undefined
 
 function mergeHook(original: ElementHook, ours: (el: Element) => void): (el: Element) => void {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -30,6 +30,8 @@ export default defineNuxtPlugin(() => {
 
     // Expose registries globally so Vite transform shims can reach them
     if (import.meta.client) {
+        // Always clear any previous registry to avoid cross-project state
+        delete (window as ObservatoryWindow).__observatory__
         ;(window as ObservatoryWindow).__observatory__ = {
             fetch: fetchRegistry,
             provideInject: provideInjectRegistry,
@@ -48,15 +50,30 @@ export default defineNuxtPlugin(() => {
             }
 
             const source = event.source as Window | null
-            source?.postMessage(
-                {
-                    type: 'observatory:snapshot',
-                    data: {
-                        transitions: transitionRegistry.getAll(),
+
+            try {
+                const snapshot = {
+                    fetch: fetchRegistry.getAll(),
+                    provideInject: provideInjectRegistry.getAll(),
+                    composables: composableRegistry.getAll(),
+                    renders: renderRegistry.getAll(),
+                    transitions: transitionRegistry.getAll(),
+                }
+
+                // Serialize snapshot to guarantee structured clone compliance
+                const payload = JSON.stringify(snapshot)
+
+                source?.postMessage(
+                    {
+                        type: 'observatory:snapshot',
+                        data: payload,
                     },
-                },
-                '*'
-            )
+                    '*'
+                )
+            } catch (err) {
+                // Optionally log serialization errors
+                console.warn('Observatory snapshot serialization failed:', err)
+            }
         })
     }
 
@@ -64,6 +81,13 @@ export default defineNuxtPlugin(() => {
     nuxtApp.hook('app:mounted', () => {
         broadcastAll()
     })
+
+    // Broadcast on every route change (client-side navigation)
+    if (import.meta.client && nuxtApp.vueApp.config.globalProperties.$router) {
+        nuxtApp.vueApp.config.globalProperties.$router.afterEach(() => {
+            broadcastAll()
+        })
+    }
 
     function broadcastAll() {
         if (!import.meta.client) {

--- a/src/transforms/composable-transform.ts
+++ b/src/transforms/composable-transform.ts
@@ -171,13 +171,20 @@ export function composableTrackerPlugin(): Plugin {
                 const importLine = `import { __trackComposable } from 'nuxt-devtools-observatory/runtime/composable-registry';\n`
                 const output = generate(ast, { retainLines: true }, scriptCode)
 
-                if (isVue) {
-                    const newCode = code.slice(0, scriptStart) + importLine + output.code + code.slice(scriptStart + scriptCode.length)
+                // Avoid duplicate imports
+                let finalCode: string
 
-                    return { code: newCode }
+                if (isVue) {
+                    finalCode =
+                        code.slice(0, scriptStart) +
+                        (scriptCode.includes('__trackComposable') ? '' : importLine) +
+                        output.code +
+                        code.slice(scriptStart + scriptCode.length)
+                } else {
+                    finalCode = (scriptCode.includes('__trackComposable') ? '' : importLine) + output.code
                 }
 
-                return { code: importLine + output.code, map: output.map }
+                return { code: finalCode, map: output.map }
             } catch (err) {
                 console.warn('[observatory] composable transform error:', err)
 

--- a/src/transforms/fetch-transform.ts
+++ b/src/transforms/fetch-transform.ts
@@ -36,6 +36,7 @@ export function fetchInstrumentPlugin(): Plugin {
 
         transform(code, id) {
             const isVue = id.endsWith('.vue')
+
             if (!isVue && !id.endsWith('.ts') && !id.endsWith('.js')) {
                 return
             }
@@ -104,26 +105,41 @@ export function fetchInstrumentPlugin(): Plugin {
 
                         const originalName = callee.name
                         const args = path.node.arguments
-                        const urlArg = args[0] ?? t.stringLiteral('')
-                        const optsArg = args[1] ?? t.objectExpression([])
 
-                        // Extract or generate a key
+                        // Detect useAsyncData signature: (handler) or (key, handler, opts)
+                        let keyArg: t.Expression | undefined = undefined
+                        let handlerArg: t.Expression | undefined = undefined
+                        let optsArg: t.Expression | undefined = undefined
+
+                        // Helper to check if node is Expression
+                        function getExpr(node: t.Node | null | undefined): t.Expression | undefined {
+                            return t.isExpression(node) ? node : undefined
+                        }
+
+                        if (originalName === 'useAsyncData' || originalName === 'useLazyAsyncData') {
+                            if (args.length === 1 && getExpr(args[0])) {
+                                // useAsyncData(handler)
+                                handlerArg = getExpr(args[0])
+                            } else if (args.length >= 2 && getExpr(args[0]) && getExpr(args[1])) {
+                                // useAsyncData(key, handler, opts?)
+                                keyArg = getExpr(args[0])
+                                handlerArg = getExpr(args[1])
+                                optsArg = getExpr(args[2]) ?? t.objectExpression([])
+                            } else {
+                                // If arguments are not valid Expressions, skip transform
+                                return
+                            }
+                        } else {
+                            // useFetch(url, opts?)
+                            keyArg = getExpr(args[0]) ?? t.stringLiteral('')
+                            optsArg = getExpr(args[1]) ?? t.objectExpression([])
+                        }
+
+                        // Extract or generate a key for meta
                         let key = originalName
 
-                        if (t.isObjectExpression(optsArg)) {
-                            const keyProp = optsArg.properties.find(
-                                (p: t.ObjectMethod | t.ObjectProperty | t.SpreadElement) =>
-                                    t.isObjectProperty(p) && t.isIdentifier(p.key) && (p.key as t.Identifier).name === 'key'
-                            ) as t.ObjectProperty | undefined
-
-                            if (keyProp && t.isStringLiteral(keyProp.value)) {
-                                key = keyProp.value.value
-                            } else {
-                                // Derive key from URL if it's a string literal
-                                if (t.isStringLiteral(urlArg)) {
-                                    key = urlArg.value.replace(/[^a-z0-9]/gi, '-').replace(/^-+|-+$/g, '')
-                                }
-                            }
+                        if (keyArg && t.isStringLiteral(keyArg)) {
+                            key = keyArg.value.replace(/[^a-z0-9]/gi, '-').replace(/^-+|-+$/g, '')
                         }
 
                         const loc = path.node.loc
@@ -134,10 +150,45 @@ export function fetchInstrumentPlugin(): Plugin {
                             t.objectProperty(t.identifier('originalFn'), t.stringLiteral(originalName)),
                         ])
 
-                        // Replace: useFetch(url, opts) → __devFetch(useFetch, url, opts, meta)
-                        path.replaceWith(t.callExpression(t.identifier('__devFetch'), [t.identifier(originalName), urlArg, optsArg, meta]))
+                        // Replace with correct signature
+                        if (originalName === 'useAsyncData' || originalName === 'useLazyAsyncData') {
+                            if (handlerArg) {
+                                // Wrap only the handler argument
+                                const wrappedHandler = t.callExpression(t.identifier('__devFetch'), [
+                                    handlerArg,
+                                    keyArg ?? t.stringLiteral(key),
+                                    meta,
+                                ])
 
-                        modified = true
+                                if (keyArg) {
+                                    // useAsyncData(key, handler, opts?)
+                                    path.replaceWith(
+                                        t.callExpression(t.identifier(originalName), [
+                                            keyArg,
+                                            wrappedHandler,
+                                            optsArg ?? t.objectExpression([]),
+                                        ])
+                                    )
+                                } else {
+                                    // useAsyncData(handler)
+                                    path.replaceWith(t.callExpression(t.identifier(originalName), [wrappedHandler]))
+                                }
+
+                                modified = true
+                            }
+                        } else {
+                            // useFetch(url, opts?)
+                            path.replaceWith(
+                                t.callExpression(t.identifier('__devFetch'), [
+                                    t.identifier(originalName),
+                                    keyArg ?? t.stringLiteral(''),
+                                    optsArg ?? t.objectExpression([]),
+                                    meta,
+                                ])
+                            )
+
+                            modified = true
+                        }
                     },
                 })
 

--- a/src/transforms/fetch-transform.ts
+++ b/src/transforms/fetch-transform.ts
@@ -191,19 +191,20 @@ export function fetchInstrumentPlugin(): Plugin {
                     return null
                 }
 
-                // Inject the shim import at the top of the file
+                // Inject the shim import at the top of the file, avoid duplicates
                 const importStatement = hasImport ? '' : `import { __devFetch } from 'nuxt-devtools-observatory/runtime/fetch-registry';\n`
-
                 const output = generate(ast, { retainLines: true }, scriptCode)
 
-                if (isVue) {
-                    const newCode = code.slice(0, scriptStart) + importStatement + output.code + code.slice(scriptStart + scriptCode.length)
+                let finalCode: string
 
-                    return { code: newCode }
+                if (isVue) {
+                    finalCode = code.slice(0, scriptStart) + importStatement + output.code + code.slice(scriptStart + scriptCode.length)
+                } else {
+                    finalCode = importStatement + output.code
                 }
 
                 return {
-                    code: importStatement + output.code,
+                    code: finalCode,
                     map: output.map,
                 }
             } catch (err) {

--- a/src/transforms/fetch-transform.ts
+++ b/src/transforms/fetch-transform.ts
@@ -41,13 +41,8 @@ export function fetchInstrumentPlugin(): Plugin {
                 return
             }
 
-            // Skip the observatory's own runtime files to prevent infinite recursion
-            if (
-                id.includes('node_modules') ||
-                id.includes('composable-registry') ||
-                id.includes('provide-inject-registry') ||
-                id.includes('fetch-registry')
-            ) {
+            // Only skip files in node_modules to avoid double-transforming dependencies
+            if (id.includes('node_modules')) {
                 return
             }
 

--- a/src/transforms/provide-inject-transform.ts
+++ b/src/transforms/provide-inject-transform.ts
@@ -126,13 +126,20 @@ export function provideInjectPlugin(): Plugin {
                 const importLine = `import { __devProvide, __devInject } from 'nuxt-devtools-observatory/runtime/provide-inject-registry';\n`
                 const output = generate(ast, { retainLines: true }, scriptCode)
 
-                if (isVue) {
-                    const newCode = code.slice(0, scriptStart) + importLine + output.code + code.slice(scriptStart + scriptCode.length)
+                // Avoid duplicate imports
+                let finalCode: string
 
-                    return { code: newCode }
+                if (isVue) {
+                    finalCode =
+                        code.slice(0, scriptStart) +
+                        (scriptCode.includes('__devProvide') ? '' : importLine) +
+                        output.code +
+                        code.slice(scriptStart + scriptCode.length)
+                } else {
+                    finalCode = (scriptCode.includes('__devProvide') ? '' : importLine) + output.code
                 }
 
-                return { code: importLine + output.code, map: output.map }
+                return { code: finalCode, map: output.map }
             } catch (err) {
                 console.warn('[observatory] provide/inject transform error:', err)
 


### PR DESCRIPTION
feat: integrate live observatory data into FetchDashboard and ProvideInjectGraph views

- Replaced mock data with live data from the Nuxt registry in FetchDashboard.vue.
- Updated computed properties to handle potential null values from live data.
- Refactored ProvideInjectGraph.vue to use live data for the provide/inject graph.
- Introduced ComponentBlock.vue for rendering component nodes in RenderHeatmap.vue.
- Enhanced error handling and data sanitization in various composables.