### PR TITLE
Enhance JSON import/export functionality and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 # Nuxt DevTools Observatory
 
+> [!WARNING]
+> **Performance note:** Instrumentation wraps every useFetch, composable, and lifecycle hook. In large apps this can slow down the DevTools UI or increase memory usage. Disable unused features via the observatory config.
+
 Nuxt DevTools module providing six missing observability features:
 
 - **useFetch Dashboard** — central view of all async data calls, cache keys, waterfall timeline
@@ -381,16 +384,26 @@ src/
 │   ├── provide-inject-transform.ts     ← AST wraps provide/inject
 │   ├── composable-transform.ts         ← AST wraps useX() composables
 │   └── transition-transform.ts         ← Virtual vue proxy — overrides Transition export
-├── runtime/
-│   ├── plugin.ts                       ← Client runtime bootstrap + RPC/Vite WS bridge
-│   └── composables/
-│       ├── fetch-registry.ts           ← Fetch tracking store + __devFetch shim
-│       ├── provide-inject-registry.ts  ← Injection tracking + __devProvide/__devInject
-│       ├── composable-registry.ts      ← Composable tracking + __trackComposable + leak detection
-│       ├── render-registry.ts          ← Render performance data via PerformanceObserver
-│       └── transition-registry.ts      ← Transition lifecycle store
-└── nitro/
-    └── fetch-capture.ts                ← SSR-side fetch timing
+└── runtime/
+    ├── plugin.ts                       ← Client runtime bootstrap + RPC/Vite WS bridge
+    ├── composables/
+    │   ├── fetch-registry.ts           ← Fetch tracking store + __devFetch shim
+    │   ├── provide-inject-registry.ts  ← Injection tracking + __devProvide/__devInject
+    │   ├── composable-registry.ts      ← Composable tracking + __trackComposable + leak detection
+    │   ├── render-registry.ts          ← Render performance data via PerformanceObserver
+    │   └── transition-registry.ts      ← Transition lifecycle store
+    ├── instrumentation/
+    │   ├── route.ts                    ← router.afterEach hook — opens/closes traces per navigation
+    │   ├── component.ts                ← Vue mixin lifecycle hooks — component + render spans
+    │   ├── fetch.ts                    ← useFetch/useAsyncData span recording
+    │   └── asyncData.ts                ← useAsyncData-specific span handling
+    ├── tracing/
+    │   ├── trace.ts                    ← Span + Trace types (server-side internal)
+    │   ├── traceStore.ts               ← In-memory Map<string, Trace> store
+    │   ├── tracing.ts                  ← Span open/close helpers
+    │   └── context.ts                  ← Current-trace context (per async task)
+    └── nitro/
+        └── fetch-capture.ts            ← SSR-side fetch timing
 
 client/
 ├── index.html
@@ -402,12 +415,16 @@ client/
     ├── style.css                       ← Design system
     ├── components/
     ├── composables/
-    │   └── useExportImport.ts          ← JSON export (download) and import (file picker) utilities
+    │   ├── useExportImport.ts          ← JSON export (download) and import (file picker) utilities
+    │   ├── useResizablePane.ts         ← Resizable split-pane drag handle
+    │   └── useTraceFilter.ts           ← Trace filter state and filtering logic
     ├── stores/
     └── views/
         ├── FetchDashboard.vue          ← useFetch tab UI
         ├── ProvideInjectGraph.vue      ← provide/inject tab UI
         ├── ComposableTracker.vue       ← Composable tab UI
+        ├── ComponentBlock.vue          ← Shared component detail block
+        ├── ValueInspector.vue          ← Inline JSON value inspector
         ├── RenderHeatmap.vue           ← Heatmap tab UI
         ├── TransitionTimeline.vue      ← Transition tracker tab UI
         └── TraceViewer.vue             ← Trace viewer tab UI (Flamegraph + Waterfall + Inspector)
@@ -417,17 +434,30 @@ playground/
 ├── nuxt.config.ts
 ├── composables/
 │   ├── useCounter.ts                   ← Clean composable (properly cleaned up)
-│   └── useLeakyPoller.ts               ← Intentionally leaky (for demo)
+│   ├── useLeakyPoller.ts               ← Intentionally leaky (for demo)
+│   ├── useCart.ts                      ← Cart state composable
+│   ├── useDashboard.ts                 ← Dashboard data composable
+│   ├── useLeakyCartAudit.ts            ← Leaky audit poller (for demo)
+│   ├── usePersistentCartSummary.ts     ← Cart summary across navigations
+│   ├── useProductFilter.ts             ← Product search/filter state
+│   └── useUserPreferences.ts           ← User preferences store
 ├── components/
 │   ├── ThemeConsumer.vue               ← Successfully injects 'theme'
 │   ├── MissingProviderConsumer.vue     ← Injects 'cartContext' (no provider — red node)
 │   ├── LeakyComponent.vue              ← Mounts useLeakyPoller
+│   ├── LeakyCartMonitor.vue            ← Mounts useLeakyCartAudit
 │   ├── HeavyList.vue                   ← Re-renders on every shuffle (heatmap demo)
 │   ├── PriceDisplay.vue                ← Leaf component with high render count
+│   ├── CartDrawer.vue                  ← Cart sidebar
+│   ├── CartItem.vue                    ← Individual cart item row
+│   ├── DataTable.vue                   ← Generic sortable table
+│   ├── SettingsPanel.vue               ← Settings form panel
+│   ├── StatsCard.vue                   ← Stat metric card
 │   └── transitions/
 │       ├── FadeBox.vue                 ← Healthy enter/leave transition
 │       ├── BrokenTransition.vue        ← Missing CSS classes (enter fires but stays in entering)
-│       └── CancelledTransition.vue     ← Rapid toggle triggers enter-cancelled / leave-cancelled
+│       ├── CancelledTransition.vue     ← Rapid toggle triggers enter-cancelled / leave-cancelled
+│       └── InterruptedTransition.vue   ← Back-to-back transitions trigger interrupted phase
 └── server/api/
     └── product.ts                      ← Mock API endpoint
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ The panel provides:
   panel's identity section has an `open ↗` button; both call Vite's built-in
   `/__open-in-editor` endpoint to open the component's source file in the configured
   editor
+- **Export / Import** — `↓ export` downloads the current render data (live or frozen
+  snapshot) as a `.json` file; `↑ import` loads a previously exported file and
+  automatically enters freeze mode so the imported snapshot is displayed in place of
+  live data; the freeze button label changes to `unfreeze (imported)` to signal the
+  import state
 
 **Known gaps:**
 
@@ -265,6 +270,10 @@ The panel provides:
 - **Filter panel** — filter by span type and free-text search across span names and metadata
 - **Duration labels** — spans narrower than 5 % of the timeline render their label outside the bar for readability
 - **In-progress traces** — active traces show `~Xms` (computed from the latest span end offset) rather than a hard "in progress" label
+- **Export / Import** — `↓ export` downloads all captured traces as a `.json` file
+  (always exports the full unfiltered dataset); `↑ import` loads a previously exported
+  file and freezes the view on the imported data; a `← live` button returns to the
+  live stream; the trace count label shows `(imported)` while viewing imported data
 
 **What it tells you:**
 
@@ -333,7 +342,6 @@ const result = useMyComposable()
 
 - [ ] SSR span collection (server-side navigation and composable setup)
 - [ ] Cross-trace comparison view
-- [ ] Export traces as JSON
 
 ## Development
 
@@ -393,6 +401,8 @@ client/
     ├── main.ts
     ├── style.css                       ← Design system
     ├── components/
+    ├── composables/
+    │   └── useExportImport.ts          ← JSON export (download) and import (file picker) utilities
     ├── stores/
     └── views/
         ├── FetchDashboard.vue          ← useFetch tab UI

--- a/client/src/composables/useExportImport.ts
+++ b/client/src/composables/useExportImport.ts
@@ -1,0 +1,63 @@
+export interface ObservatoryExportFile<T> {
+    type: 'observatory-traces' | 'observatory-renders'
+    version: '1'
+    exportedAt: number
+    count: number
+    data: T[]
+}
+
+export function exportJson(filename: string, envelope: ObservatoryExportFile<unknown>): void {
+    const json = JSON.stringify(envelope, null, 2)
+    const blob = new Blob([json], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filename
+    anchor.click()
+    URL.revokeObjectURL(url)
+}
+
+export function importJson(): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+        const input = document.createElement('input')
+        input.type = 'file'
+        input.accept = '.json,application/json'
+
+        input.addEventListener('change', () => {
+            const file = input.files?.[0]
+
+            if (!file) {
+                reject(new Error('No file selected'))
+                return
+            }
+
+            const reader = new FileReader()
+
+            reader.addEventListener('load', () => {
+                try {
+                    resolve(JSON.parse(reader.result as string))
+                } catch {
+                    reject(new Error('Invalid JSON file'))
+                }
+            })
+
+            reader.addEventListener('error', () => reject(new Error('Failed to read file')))
+            reader.readAsText(file)
+        })
+
+        // Reject if the dialog is cancelled (focus returns without a change event)
+        window.addEventListener(
+            'focus',
+            () => {
+                setTimeout(() => {
+                    if (!input.files?.length) {
+                        reject(new Error('cancelled'))
+                    }
+                }, 300)
+            },
+            { once: true }
+        )
+
+        input.click()
+    })
+}

--- a/client/src/views/RenderHeatmap.vue
+++ b/client/src/views/RenderHeatmap.vue
@@ -699,8 +699,7 @@ async function handleImport() {
 
     try {
         parsed = await importJson()
-    }
-    catch (err) {
+    } catch (err) {
         if (err instanceof Error && err.message !== 'cancelled') {
             alert(`Import failed: ${err.message}`)
         }
@@ -710,10 +709,10 @@ async function handleImport() {
     const file = parsed as ObservatoryExportFile<RenderEntry>
 
     if (
-        file?.type !== 'observatory-renders'
-        || file?.version !== '1'
-        || !Array.isArray(file?.data)
-        || (file.data.length > 0 && (file.data[0]?.uid === undefined || !file.data[0]?.name || !file.data[0]?.file))
+        file?.type !== 'observatory-renders' ||
+        file?.version !== '1' ||
+        !Array.isArray(file?.data) ||
+        (file.data.length > 0 && (file.data[0]?.uid === undefined || !file.data[0]?.name || !file.data[0]?.file))
     ) {
         alert('Invalid observatory renders file.')
         return
@@ -778,12 +777,8 @@ function formatTimestamp(t: number): string {
             <button :class="{ active: frozen }" class="render-heatmap__freeze tracker-toolbar__spacer" @click="toggleFreeze">
                 {{ frozen && isImportedSnapshot ? 'unfreeze (imported)' : frozen ? 'unfreeze' : 'freeze snapshot' }}
             </button>
-            <button class="render-heatmap__action-btn" title="Export render data as JSON" @click="handleExport">
-                ↓ export
-            </button>
-            <button class="render-heatmap__action-btn" title="Import render data from JSON file" @click="handleImport">
-                ↑ import
-            </button>
+            <button class="render-heatmap__action-btn" title="Export render data as JSON" @click="handleExport">↓ export</button>
+            <button class="render-heatmap__action-btn" title="Import render data from JSON file" @click="handleImport">↑ import</button>
         </div>
 
         <div class="render-heatmap__stats tracker-stats-row">

--- a/client/src/views/RenderHeatmap.vue
+++ b/client/src/views/RenderHeatmap.vue
@@ -2,6 +2,8 @@
 import { computed, defineComponent, h, ref, watch, type VNode } from 'vue'
 import { useResizablePane } from '@observatory-client/composables/useResizablePane'
 import { useObservatoryData, openInEditor as openInEditorFromStore } from '@observatory-client/stores/observatory'
+import { exportJson, importJson } from '@observatory-client/composables/useExportImport'
+import type { ObservatoryExportFile } from '@observatory-client/composables/useExportImport'
 import type { RenderEntry, RenderEvent } from '@observatory/types/snapshot'
 
 interface ComponentNode {
@@ -197,6 +199,7 @@ const activeThreshold = computed({
 })
 const activeHotOnly = ref(false)
 const frozen = ref(false)
+const isImportedSnapshot = ref(false)
 const search = ref('')
 const activeSelectedId = ref<string | null>(null)
 const activeRootId = ref<string | null>(null)
@@ -671,6 +674,7 @@ function updateSearch(event: Event) {
 function toggleFreeze() {
     if (frozen.value) {
         frozen.value = false
+        isImportedSnapshot.value = false
         frozenSnapshot.value = []
 
         return
@@ -678,6 +682,46 @@ function toggleFreeze() {
 
     frozenSnapshot.value = JSON.parse(JSON.stringify(renders.value)) as RenderEntry[]
     frozen.value = true
+}
+
+function handleExport() {
+    exportJson(`observatory-renders-${Date.now()}.json`, {
+        type: 'observatory-renders',
+        version: '1',
+        exportedAt: Date.now(),
+        count: displayEntries.value.length,
+        data: displayEntries.value,
+    })
+}
+
+async function handleImport() {
+    let parsed: unknown
+
+    try {
+        parsed = await importJson()
+    }
+    catch (err) {
+        if (err instanceof Error && err.message !== 'cancelled') {
+            alert(`Import failed: ${err.message}`)
+        }
+        return
+    }
+
+    const file = parsed as ObservatoryExportFile<RenderEntry>
+
+    if (
+        file?.type !== 'observatory-renders'
+        || file?.version !== '1'
+        || !Array.isArray(file?.data)
+        || (file.data.length > 0 && (file.data[0]?.uid === undefined || !file.data[0]?.name || !file.data[0]?.file))
+    ) {
+        alert('Invalid observatory renders file.')
+        return
+    }
+
+    frozenSnapshot.value = file.data
+    frozen.value = true
+    isImportedSnapshot.value = true
 }
 
 function basename(file: string) {
@@ -732,7 +776,13 @@ function formatTimestamp(t: number): string {
                 <option v-for="r in knownRoutes" :key="r" :value="r">{{ r }}</option>
             </select>
             <button :class="{ active: frozen }" class="render-heatmap__freeze tracker-toolbar__spacer" @click="toggleFreeze">
-                {{ frozen ? 'unfreeze' : 'freeze snapshot' }}
+                {{ frozen && isImportedSnapshot ? 'unfreeze (imported)' : frozen ? 'unfreeze' : 'freeze snapshot' }}
+            </button>
+            <button class="render-heatmap__action-btn" title="Export render data as JSON" @click="handleExport">
+                ↓ export
+            </button>
+            <button class="render-heatmap__action-btn" title="Import render data from JSON file" @click="handleImport">
+                ↑ import
             </button>
         </div>
 
@@ -950,6 +1000,23 @@ function formatTimestamp(t: number): string {
 
 .render-heatmap__threshold-range {
     width: 90px;
+}
+
+.render-heatmap__action-btn {
+    padding: 3px 8px;
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 11px;
+    border-radius: 3px;
+    transition: all 0.12s;
+    font-family: var(--mono);
+}
+
+.render-heatmap__action-btn:hover {
+    background: var(--bg-secondary);
+    color: var(--text);
 }
 
 .stat-sub {

--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -6,9 +6,14 @@ import WaterfallView from '@observatory-client/components/WaterfallView.vue'
 import SpanInspector from '@observatory-client/components/SpanInspector.vue'
 import TraceFilter from '@observatory-client/components/TraceFilter.vue'
 import { useTraceFilter } from '@observatory-client/composables/useTraceFilter'
+import { exportJson, importJson } from '@observatory-client/composables/useExportImport'
+import type { ObservatoryExportFile } from '@observatory-client/composables/useExportImport'
 import type { TraceEntry, TraceSpan } from '@observatory/types/snapshot'
 
 const { traces, connected } = useObservatoryData()
+
+const importedTraces = ref<TraceEntry[]>([])
+const isImportMode = computed(() => importedTraces.value.length > 0)
 
 const selectedTraceId = ref<string | null>(null)
 const selectedSpan = ref<TraceSpan | undefined>(undefined)
@@ -27,7 +32,8 @@ const {
 } = useTraceFilter()
 
 const sortedTraces = computed(() => {
-    return [...traces.value].sort((a, b) => b.startTime - a.startTime)
+    const source = isImportMode.value ? importedTraces.value : traces.value
+    return [...source].sort((a, b) => b.startTime - a.startTime)
 })
 
 const filteredTraces = computed(() => {
@@ -35,11 +41,13 @@ const filteredTraces = computed(() => {
 })
 
 const traceCountLabel = computed(() => {
+    const suffix = isImportMode.value ? ' (imported)' : ''
+
     if (!hasActiveFilters.value) {
-        return `${sortedTraces.value.length} traces`
+        return `${sortedTraces.value.length} traces${suffix}`
     }
 
-    return `Showing ${filteredTraces.value.length} of ${sortedTraces.value.length} traces`
+    return `Showing ${filteredTraces.value.length} of ${sortedTraces.value.length} traces${suffix}`
 })
 
 const selectedTrace = computed(() => {
@@ -139,6 +147,52 @@ function handleClearFilters() {
 function handleSpanTypesUpdate(value: Set<string>) {
     selectedSpanTypes.value = value
 }
+
+function handleExport() {
+    exportJson(`observatory-traces-${Date.now()}.json`, {
+        type: 'observatory-traces',
+        version: '1',
+        exportedAt: Date.now(),
+        count: traces.value.length,
+        data: traces.value,
+    })
+}
+
+async function handleImport() {
+    let parsed: unknown
+
+    try {
+        parsed = await importJson()
+    }
+    catch (err) {
+        if (err instanceof Error && err.message !== 'cancelled') {
+            alert(`Import failed: ${err.message}`)
+        }
+        return
+    }
+
+    const file = parsed as ObservatoryExportFile<TraceEntry>
+
+    if (
+        file?.type !== 'observatory-traces'
+        || file?.version !== '1'
+        || !Array.isArray(file?.data)
+        || (file.data.length > 0 && (!file.data[0]?.id || !file.data[0]?.name || !Array.isArray(file.data[0]?.spans)))
+    ) {
+        alert('Invalid observatory traces file.')
+        return
+    }
+
+    importedTraces.value = file.data
+    selectedTraceId.value = null
+    selectedSpan.value = undefined
+}
+
+function handleBackToLive() {
+    importedTraces.value = []
+    selectedTraceId.value = null
+    selectedSpan.value = undefined
+}
 </script>
 
 <template>
@@ -148,6 +202,29 @@ function handleSpanTypesUpdate(value: Set<string>) {
             <div class="trace-viewer__title">Trace Viewer</div>
             <div class="trace-viewer__header-actions">
                 <div class="trace-viewer__count muted text-sm">{{ traceCountLabel }}</div>
+                <button
+                    v-if="isImportMode"
+                    class="trace-viewer__import-mode-btn"
+                    title="Return to live data"
+                    @click="handleBackToLive"
+                >
+                    ← live
+                </button>
+                <button
+                    class="trace-viewer__action-btn"
+                    title="Export traces as JSON"
+                    :disabled="traces.length === 0 && !isImportMode"
+                    @click="handleExport"
+                >
+                    ↓ export
+                </button>
+                <button
+                    class="trace-viewer__action-btn"
+                    title="Import traces from JSON file"
+                    @click="handleImport"
+                >
+                    ↑ import
+                </button>
                 <button
                     :class="{ 'trace-viewer__filter-btn--active': showFilters }"
                     class="trace-viewer__filter-btn"
@@ -363,6 +440,44 @@ function handleSpanTypesUpdate(value: Set<string>) {
     background: var(--accent-bg);
     border-color: var(--accent);
     color: var(--accent);
+}
+
+.trace-viewer__action-btn {
+    padding: 3px 8px;
+    background: none;
+    border: 1px solid var(--border);
+    color: var(--text-secondary);
+    cursor: pointer;
+    font-size: 11px;
+    border-radius: 3px;
+    transition: all 0.12s;
+    font-family: var(--mono);
+}
+
+.trace-viewer__action-btn:hover:not(:disabled) {
+    background: var(--bg-secondary);
+    color: var(--text);
+}
+
+.trace-viewer__action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.trace-viewer__import-mode-btn {
+    padding: 3px 8px;
+    background: var(--accent-bg);
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    cursor: pointer;
+    font-size: 11px;
+    border-radius: 3px;
+    transition: all 0.12s;
+    font-family: var(--mono);
+}
+
+.trace-viewer__import-mode-btn:hover {
+    opacity: 0.8;
 }
 
 .trace-viewer__container {

--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -163,8 +163,7 @@ async function handleImport() {
 
     try {
         parsed = await importJson()
-    }
-    catch (err) {
+    } catch (err) {
         if (err instanceof Error && err.message !== 'cancelled') {
             alert(`Import failed: ${err.message}`)
         }
@@ -174,10 +173,10 @@ async function handleImport() {
     const file = parsed as ObservatoryExportFile<TraceEntry>
 
     if (
-        file?.type !== 'observatory-traces'
-        || file?.version !== '1'
-        || !Array.isArray(file?.data)
-        || (file.data.length > 0 && (!file.data[0]?.id || !file.data[0]?.name || !Array.isArray(file.data[0]?.spans)))
+        file?.type !== 'observatory-traces' ||
+        file?.version !== '1' ||
+        !Array.isArray(file?.data) ||
+        (file.data.length > 0 && (!file.data[0]?.id || !file.data[0]?.name || !Array.isArray(file.data[0]?.spans)))
     ) {
         alert('Invalid observatory traces file.')
         return
@@ -202,12 +201,7 @@ function handleBackToLive() {
             <div class="trace-viewer__title">Trace Viewer</div>
             <div class="trace-viewer__header-actions">
                 <div class="trace-viewer__count muted text-sm">{{ traceCountLabel }}</div>
-                <button
-                    v-if="isImportMode"
-                    class="trace-viewer__import-mode-btn"
-                    title="Return to live data"
-                    @click="handleBackToLive"
-                >
+                <button v-if="isImportMode" class="trace-viewer__import-mode-btn" title="Return to live data" @click="handleBackToLive">
                     ← live
                 </button>
                 <button
@@ -218,13 +212,7 @@ function handleBackToLive() {
                 >
                     ↓ export
                 </button>
-                <button
-                    class="trace-viewer__action-btn"
-                    title="Import traces from JSON file"
-                    @click="handleImport"
-                >
-                    ↑ import
-                </button>
+                <button class="trace-viewer__action-btn" title="Import traces from JSON file" @click="handleImport">↑ import</button>
                 <button
                     :class="{ 'trace-viewer__filter-btn--active': showFilters }"
                     class="trace-viewer__filter-btn"


### PR DESCRIPTION
This pull request adds full export and import functionality for render and trace data in the Nuxt DevTools Observatory, allowing users to download and restore snapshots of observability data as JSON files. The UI is updated to include export/import buttons in both the Render Heatmap and Trace Viewer panels, with clear indicators and handling for imported data. A new composable utility handles the JSON file operations, and the documentation is updated to reflect these new features.

**Export/Import Functionality:**

* Added a new composable utility `useExportImport.ts` that provides `exportJson` and `importJson` functions for exporting observability data as JSON and importing it back into the UI, with file validation and error handling.
* Implemented export/import buttons and logic in `RenderHeatmap.vue` and `TraceViewer.vue`, allowing users to download current data or load previously exported snapshots. The UI distinguishes between live and imported data, and provides a way to return to live mode. [[1]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R687-R725) [[2]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7L735-R781) [[3]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R202) [[4]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R677) [[5]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R150-R194) [[6]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R204-R215)

**UI/UX Improvements:**

* Updated both panels to visually indicate when imported data is being viewed (e.g., "unfreeze (imported)", trace count label shows "(imported)", and a "← live" button is available to return to live data). [[1]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7L735-R781) [[2]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24L30-R50) [[3]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R204-R215)
* Added and styled new action buttons for export/import in both panels for a consistent and accessible user experience. [[1]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R1000-R1016) [[2]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R433-R470)

**Documentation Updates:**

* Updated the `README.md` to document the new export/import features for both the Render Heatmap and Trace Viewer panels, and added references to the new composable and demo components in the codebase overview. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R230-R234) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R276-R279) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L376-R404) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R417-R427) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L410-R460)
* Added a warning about the performance impact of instrumentation and recommended disabling unused features for large apps.
* Removed the now-implemented "Export traces as JSON" from the roadmap checklist.