### PR TITLE
Implement SSR trace collection and integrate with client traceStore

### DIFF
--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -19,6 +19,8 @@ const selectedTraceId = ref<string | null>(null)
 const selectedSpan = ref<TraceSpan | undefined>(undefined)
 const viewMode = ref<'overview' | 'flamegraph' | 'waterfall'>('overview')
 const showFilters = ref(false)
+const renderSummaryOpen = ref(true)
+const highlightedUid = ref<string | number | undefined>(undefined)
 
 const {
     searchQuery,
@@ -56,6 +58,84 @@ const selectedTrace = computed(() => {
     }
 
     return filteredTraces.value.find((t) => t.id === selectedTraceId.value)
+})
+
+/** Aggregate render spans in the selected trace by component UID. */
+interface RenderSummaryRow {
+    uid: string | number
+    componentName: string
+    file: string
+    mountCount: number
+    rerenderCount: number
+    totalMs: number
+    avgMs: number
+}
+
+const renderSummary = computed<RenderSummaryRow[]>(() => {
+    if (!selectedTrace.value) {
+        return []
+    }
+
+    const byUid = new Map<string | number, { spans: TraceSpan[]; name: string; file: string }>()
+
+    for (const span of selectedTrace.value.spans) {
+        if (span.type !== 'render') {
+            continue
+        }
+
+        const m = span.metadata as Record<string, unknown> | undefined
+
+        if (!m) {
+            continue
+        }
+
+        const uid = (m.uid as string | number | undefined) ?? span.id
+        const name = String(m.componentName ?? '')
+        const file = String(m.file ?? '')
+
+        if (!byUid.has(uid)) {
+            byUid.set(uid, { spans: [], name, file })
+        }
+
+        byUid.get(uid)!.spans.push(span)
+    }
+
+    const rows: RenderSummaryRow[] = []
+
+    for (const [uid, { spans, name, file }] of byUid) {
+        let mountCount = 0
+        let rerenderCount = 0
+        let totalMs = 0
+
+        for (const span of spans) {
+            const lifecycle = String((span.metadata as Record<string, unknown> | undefined)?.lifecycle ?? '')
+            const dur = span.durationMs ?? 0
+
+            if (lifecycle === 'render:mount') {
+                mountCount++
+            } else {
+                rerenderCount++
+            }
+
+            totalMs += dur
+        }
+
+        const totalRenders = mountCount + rerenderCount
+        rows.push({
+            uid,
+            componentName: name || String(uid),
+            file,
+            mountCount,
+            rerenderCount,
+            totalMs,
+            avgMs: totalRenders > 0 ? totalMs / totalRenders : 0,
+        })
+    }
+
+    // Sort by total re-renders descending, then by total time.
+    rows.sort((a, b) => b.rerenderCount - a.rerenderCount || b.totalMs - a.totalMs)
+
+    return rows
 })
 
 function elapsedFromSpans(trace: TraceEntry): number | undefined {
@@ -137,6 +217,7 @@ function getSpanDisplayName(span: TraceSpan): string {
 function selectTrace(trace: TraceEntry) {
     selectedTraceId.value = trace.id
     selectedSpan.value = undefined
+    highlightedUid.value = undefined
 }
 
 function handleClearFilters() {
@@ -190,6 +271,13 @@ async function handleImport() {
 function handleBackToLive() {
     importedTraces.value = []
     selectedTraceId.value = null
+    selectedSpan.value = undefined
+    highlightedUid.value = undefined
+}
+
+function handleRenderSummaryRowClick(uid: string | number) {
+    // Toggle highlight: clicking the already-highlighted row deselects it.
+    highlightedUid.value = highlightedUid.value === uid ? undefined : uid
     selectedSpan.value = undefined
 }
 </script>
@@ -343,7 +431,12 @@ function handleBackToLive() {
                                 <div
                                     v-for="span in selectedTrace.spans"
                                     :key="span.id"
-                                    :class="{ 'trace-viewer__span-item--selected': selectedSpan?.id === span.id }"
+                                    :class="{
+                                        'trace-viewer__span-item--selected': selectedSpan?.id === span.id,
+                                        'trace-viewer__span-item--highlighted':
+                                            highlightedUid !== undefined &&
+                                            (span.metadata as Record<string, unknown> | undefined)?.uid === highlightedUid,
+                                    }"
                                     class="trace-viewer__span-item"
                                     @click="selectedSpan = span"
                                 >
@@ -354,6 +447,53 @@ function handleBackToLive() {
                                     </div>
                                 </div>
                             </div>
+
+                            <!-- Render Summary panel — shown when the trace has render spans -->
+                            <template v-if="renderSummary.length > 0">
+                                <div class="trace-viewer__render-summary-header" @click="renderSummaryOpen = !renderSummaryOpen">
+                                    <span class="trace-viewer__render-summary-toggle">{{ renderSummaryOpen ? '▾' : '▸' }}</span>
+                                    <span class="trace-viewer__render-summary-title">Render Summary</span>
+                                    <span class="trace-viewer__render-summary-count muted">{{ renderSummary.length }} components</span>
+                                    <span
+                                        v-if="highlightedUid !== undefined"
+                                        class="trace-viewer__render-summary-clear"
+                                        @click.stop="highlightedUid = undefined"
+                                    >
+                                        ✕ clear
+                                    </span>
+                                </div>
+                                <div v-if="renderSummaryOpen" class="trace-viewer__render-summary-table-wrap">
+                                    <table class="data-table trace-viewer__render-summary-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Component</th>
+                                                <th title="Times the component was mounted">Mounts</th>
+                                                <th title="Reactive re-renders after initial mount">Re-renders</th>
+                                                <th title="Average render duration">Avg</th>
+                                                <th title="Sum of all render durations">Total</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr
+                                                v-for="row in renderSummary"
+                                                :key="row.uid"
+                                                :class="{ 'trace-viewer__render-summary-row--active': highlightedUid === row.uid }"
+                                                class="trace-viewer__render-summary-row"
+                                                :title="row.file"
+                                                @click="handleRenderSummaryRowClick(row.uid)"
+                                            >
+                                                <td class="mono">{{ row.componentName }}</td>
+                                                <td class="mono">{{ row.mountCount }}</td>
+                                                <td class="mono" :class="{ 'trace-viewer__render-hot': row.rerenderCount > 3 }">
+                                                    {{ row.rerenderCount }}
+                                                </td>
+                                                <td class="mono">{{ formatDuration(row.avgMs) }}</td>
+                                                <td class="mono">{{ formatDuration(row.totalMs) }}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </template>
                         </div>
 
                         <!-- Flamegraph -->
@@ -673,6 +813,90 @@ function handleBackToLive() {
     border-left: 1px solid var(--border);
     background: var(--bg);
     overflow: auto;
+}
+
+.trace-viewer__span-item--highlighted {
+    background: color-mix(in srgb, var(--purple, #a855f7) 8%, transparent);
+    border-left: 2px solid var(--purple, #a855f7);
+}
+
+.trace-viewer__render-summary-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 16px;
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    background: var(--bg3, var(--bg2, var(--bg)));
+    cursor: pointer;
+    user-select: none;
+    flex-shrink: 0;
+}
+
+.trace-viewer__render-summary-header:hover {
+    background: var(--bg2, var(--bg));
+}
+
+.trace-viewer__render-summary-toggle {
+    font-size: 10px;
+    color: var(--text3, var(--text2, var(--text)));
+    width: 12px;
+    flex-shrink: 0;
+}
+
+.trace-viewer__render-summary-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text2, var(--text));
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.trace-viewer__render-summary-count {
+    font-size: 11px;
+    font-family: var(--mono);
+    color: var(--text3, var(--text2, var(--text)));
+}
+
+.trace-viewer__render-summary-clear {
+    margin-left: auto;
+    font-size: 11px;
+    color: var(--accent);
+    cursor: pointer;
+}
+
+.trace-viewer__render-summary-clear:hover {
+    text-decoration: underline;
+}
+
+.trace-viewer__render-summary-table-wrap {
+    flex-shrink: 0;
+    max-height: 200px;
+    overflow: auto;
+    border-bottom: 1px solid var(--border);
+}
+
+.trace-viewer__render-summary-table {
+    width: 100%;
+}
+
+.trace-viewer__render-summary-row {
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.trace-viewer__render-summary-row:hover {
+    background: var(--bg2, var(--bg));
+}
+
+.trace-viewer__render-summary-row--active {
+    background: color-mix(in srgb, var(--purple, #a855f7) 8%, transparent);
+    border-left: 2px solid var(--purple, #a855f7);
+}
+
+.trace-viewer__render-hot {
+    color: var(--orange, #f97316);
+    font-weight: 600;
 }
 
 @media (max-width: 1024px) {

--- a/src/module.ts
+++ b/src/module.ts
@@ -278,8 +278,8 @@ export default defineNuxtModule<ModuleOptions>({
             addPlugin(resolver.resolve('./runtime/plugin'))
         }
 
-        // ── Nitro plugin for SSR fetch capture ────────────────────────────────
-        if (resolved.fetchDashboard) {
+        // ── Nitro plugin for SSR fetch capture / trace injection ──────────────
+        if (resolved.fetchDashboard || (resolved.traceViewer && resolved.instrumentServer)) {
             addServerPlugin(resolver.resolve('./runtime/nitro/fetch-capture'))
         }
 

--- a/src/runtime/nitro/fetch-capture.ts
+++ b/src/runtime/nitro/fetch-capture.ts
@@ -1,31 +1,117 @@
-import type { H3Event } from 'h3'
-import { setResponseHeader } from 'h3'
+import { getRequestURL, setResponseHeader, type H3Event } from 'h3'
+import { createSsrRecord, drainSsrRecord, type SsrTraceRecord } from './ssr-trace-store'
 
-interface ObservatoryEvent extends H3Event {
+interface ObservatoryContext {
+    __observatoryRequestId?: string
     __ssrFetchStart?: number
+}
+
+// Nitro plugins receive plain H3Event objects; extend the context inline.
+type ObservatoryEvent = H3Event & { context: H3Event['context'] & ObservatoryContext }
+
+// Nitro's render:html HTML context (subset of NitroRenderHTMLContext).
+interface NitroRenderHTMLContext {
+    island?: boolean
+    html: string
+    head: string[]
+    bodyPrepend: string[]
+    body: string[]
+    bodyAppend: string[]
 }
 
 interface NitroAppLike {
     hooks: {
-        hook: (name: 'request' | 'afterResponse', handler: (event: H3Event) => void) => void
+        // Use a broad signature so we can register all three hook names without
+        // TypeScript requiring a union-overloaded interface.
+        hook: (name: string, handler: (...args: unknown[]) => void) => void
     }
 }
 
-// Nitro plugin: captures server-side $fetch calls and annotates
-// responses with cache status headers for the client to detect.
+let _requestCounter = 0
 
+function newRequestId(): string {
+    _requestCounter = (_requestCounter + 1) % 999_999
+
+    return `req_${Date.now()}_${_requestCounter}`
+}
+
+// Nitro plugin: captures SSR request timing and injects a trace record into
+// the rendered HTML so the client Observatory plugin can pick it up.
 export default function fetchCapturePlugin(nitroApp: NitroAppLike) {
-    // Record request timing so the client can identify SSR-backed payloads.
-    nitroApp.hooks.hook('request', (event) => {
-        ;(event as ObservatoryEvent).__ssrFetchStart = performance.now()
+    // ── request ────────────────────────────────────────────────────────────
+    // Open a per-request SSR trace record and stamp the request start time.
+    nitroApp.hooks.hook('request', (...args: unknown[]) => {
+        const event = args[0] as ObservatoryEvent
+
+        const start = performance.now()
+        event.context.__ssrFetchStart = start
+
+        let route = '/'
+        try {
+            route = getRequestURL(event).pathname
+        } catch (error) {
+            console.error('Error getting request URL:', error)
+        }
+
+        const method = String((event as H3Event & { method?: string }).method ?? event.node?.req?.method ?? 'GET').toUpperCase()
+
+        const requestId = newRequestId()
+        event.context.__observatoryRequestId = requestId
+
+        createSsrRecord(requestId, route, method)
     })
 
-    nitroApp.hooks.hook('afterResponse', (event) => {
-        const start = (event as ObservatoryEvent).__ssrFetchStart
+    // ── afterResponse ──────────────────────────────────────────────────────
+    // Annotate the response with total SSR duration for easy identification.
+    // Also drain any record that was never picked up by render:html (e.g. API
+    // routes or error responses that do not render HTML).
+    nitroApp.hooks.hook('afterResponse', (...args: unknown[]) => {
+        const event = args[0] as ObservatoryEvent
+        const start = event.context.__ssrFetchStart
 
-        if (start) {
+        if (start !== undefined) {
             const ms = Math.round(performance.now() - start)
             setResponseHeader(event, 'x-observatory-ssr-ms', String(ms))
         }
+
+        // Drain leftover record so the Map does not grow for non-HTML responses.
+        const requestId = event.context.__observatoryRequestId
+
+        if (requestId) {
+            const durationMs = start !== undefined ? Math.max(performance.now() - start, 0) : 0
+            drainSsrRecord(requestId, durationMs)
+        }
+    })
+
+    // ── render:html ────────────────────────────────────────────────────────
+    // Inject the completed SSR trace as inline JSON so the client plugin can
+    // merge it into the client-side traceStore on startup.
+    nitroApp.hooks.hook('render:html', (...args: unknown[]) => {
+        const html = args[0] as NitroRenderHTMLContext
+        const ctx = args[1] as { event: ObservatoryEvent }
+        const event = ctx?.event
+
+        if (!event) {
+            return
+        }
+
+        const requestId = event.context.__observatoryRequestId
+        const start = event.context.__ssrFetchStart
+
+        if (!requestId) {
+            return
+        }
+
+        const durationMs = start !== undefined ? Math.max(performance.now() - start, 0) : 0
+        const record: SsrTraceRecord | undefined = drainSsrRecord(requestId, durationMs)
+
+        if (!record) {
+            return
+        }
+
+        // Inject as a JSON script block. The closing </script> tag is escaped
+        // to prevent the parser from treating it as the end of a real script.
+        const json = JSON.stringify(record).replace(/<\/script>/gi, '<\\/script>')
+        html.bodyAppend.push(`<script id="__observatory_ssr_spans__" type="application/json">${json}</script>`)
     })
 }

--- a/src/runtime/nitro/ssr-trace-store.ts
+++ b/src/runtime/nitro/ssr-trace-store.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-request SSR trace collector.
+ *
+ * Each incoming SSR page request gets its own record keyed by a unique
+ * requestId (stored on H3 `event.context`). Spans are accumulated during the
+ * request lifecycle and drained once the HTML is rendered (via the
+ * `render:html` Nitro hook), so they can be injected into the page as inline
+ * JSON for the client plugin to pick up.
+ */
+
+export interface SsrSpan {
+    id: string
+    name: string
+    type: string
+    /** Milliseconds relative to request start (0 = request began). */
+    startTime: number
+    endTime?: number
+    durationMs?: number
+    status: 'ok' | 'error' | 'active'
+    metadata?: Record<string, unknown>
+}
+
+export interface SsrTraceRecord {
+    traceId: string
+    name: string
+    spans: SsrSpan[]
+}
+
+const pending = new Map<string, SsrTraceRecord>()
+
+let _counter = 0
+
+function newId(prefix: string): string {
+    _counter = (_counter + 1) % 999_999
+
+    return `${prefix}_ssr_${Date.now()}_${_counter}`
+}
+
+/**
+ * Open a new per-request SSR record. A `navigation` span covering the full
+ * request is pre-populated; its end time is filled in when `drainSsrRecord`
+ * is called.
+ * @param {string} requestId - Unique identifier for the HTTP request, stored in `event.context`.
+ * @param {string} route - Request pathname (e.g. `/dashboard`).
+ * @param {string} method - HTTP method in upper-case (e.g. `GET`).
+ * @returns {SsrTraceRecord} The newly created `SsrTraceRecord` keyed by `requestId`.
+ */
+export function createSsrRecord(requestId: string, route: string, method: string): SsrTraceRecord {
+    const record: SsrTraceRecord = {
+        traceId: newId('trace'),
+        name: `ssr:${route}`,
+        spans: [
+            {
+                id: newId('span'),
+                name: 'ssr:navigation',
+                type: 'navigation',
+                startTime: 0,
+                status: 'active',
+                metadata: {
+                    origin: 'ssr',
+                    route,
+                    method,
+                },
+            },
+        ],
+    }
+
+    pending.set(requestId, record)
+
+    return record
+}
+
+/**
+ * Append an SSR-side fetch span. `startMs` / `endMs` are milliseconds
+ * relative to request start (same origin as `createSsrRecord`).
+ * @param {string} requestId - The request identifier returned by `createSsrRecord`.
+ * @param {object} opts - Span options.
+ * @param {string} opts.url - The request URL or path that was fetched.
+ * @param {string} opts.method - HTTP method in upper-case (e.g. `GET`).
+ * @param {number} opts.startMs - Span start, in ms relative to the request start time.
+ * @param {number} opts.endMs - Span end, in ms relative to the request start time.
+ * @param {number} [opts.statusCode] - Optional HTTP response status code.
+ * @param {boolean} [opts.error] - Set to `true` to mark the span status as `error`.
+ */
+export function addSsrFetchSpan(
+    requestId: string,
+    opts: {
+        url: string
+        method: string
+        startMs: number
+        endMs: number
+        statusCode?: number
+        error?: boolean
+    },
+): void {
+    const record = pending.get(requestId)
+
+    if (!record) {
+        return
+    }
+
+    const durationMs = Math.max(opts.endMs - opts.startMs, 0)
+
+    record.spans.push({
+        id: newId('span'),
+        name: opts.url,
+        type: 'fetch',
+        startTime: opts.startMs,
+        endTime: opts.endMs,
+        durationMs,
+        status: opts.error ? 'error' : 'ok',
+        metadata: {
+            origin: 'ssr',
+            url: opts.url,
+            method: opts.method,
+            statusCode: opts.statusCode,
+        },
+    })
+}
+
+/**
+ * Finalize and remove the record for `requestId`. The pre-populated
+ * navigation span is closed with `durationMs`. Returns `undefined` if the
+ * requestId is unknown (e.g. non-page requests that never called
+ * `createSsrRecord`).
+ * @param {string} requestId - The request identifier returned by `createSsrRecord`.
+ * @param {number} durationMs - Total SSR request duration in milliseconds, used to close the navigation span.
+ * @returns {SsrTraceRecord | undefined} The completed `SsrTraceRecord`, or `undefined` if no record exists for `requestId`.
+ */
+export function drainSsrRecord(requestId: string, durationMs: number): SsrTraceRecord | undefined {
+    const record = pending.get(requestId)
+
+    pending.delete(requestId)
+
+    if (!record) {
+        return undefined
+    }
+
+    const navSpan = record.spans[0]
+
+    if (navSpan) {
+        navSpan.endTime = durationMs
+        navSpan.durationMs = durationMs
+        navSpan.status = 'ok'
+    }
+
+    return record
+}

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -78,6 +78,79 @@ export default defineNuxtPlugin(() => {
         registries.transition = setupTransitionRegistry()
     }
 
+    // Read the SSR trace injected by the Nitro plugin and merge its spans into
+    // the client traceStore so the Trace Viewer shows an `ssr:` prefixed trace
+    // for the initial page load alongside the subsequent client navigations.
+    function mergeSsrSpans() {
+        if (!import.meta.client) {
+            return
+        }
+
+        const el = document.getElementById('__observatory_ssr_spans__')
+
+        if (!el) {
+            return
+        }
+
+        let record: {
+            traceId: string
+            name: string
+            spans: Array<{
+                id: string
+                name: string
+                type: string
+                startTime: number
+                endTime?: number
+                durationMs?: number
+                status: 'ok' | 'error' | 'active'
+                metadata?: Record<string, unknown>
+            }>
+        }
+
+        try {
+            record = JSON.parse(el.textContent ?? '')
+        } catch {
+            return
+        }
+
+        if (!record?.traceId || !Array.isArray(record.spans)) {
+            return
+        }
+
+        // Anchor the SSR trace just before now so it appears at the top of the
+        // trace list (most recent). Span times are relative to request start
+        // (startTime: 0 = request began), so we compute an absolute base by
+        // subtracting the navigation span duration from performance.now().
+        const navDurationMs = record.spans[0]?.durationMs ?? 0
+        const traceStartTime = performance.now() - navDurationMs
+
+        traceStore.createTrace({
+            id: record.traceId,
+            name: record.name,
+            startTime: traceStartTime,
+            metadata: { origin: 'ssr' },
+        })
+
+        for (const span of record.spans) {
+            traceStore.addSpan({
+                id: span.id,
+                traceId: record.traceId,
+                name: span.name,
+                type: span.type,
+                startTime: traceStartTime + span.startTime,
+                endTime: span.endTime !== undefined ? traceStartTime + span.endTime : undefined,
+                status: span.status,
+                metadata: { ...(span.metadata ?? {}), origin: 'ssr' },
+            })
+        }
+
+        traceStore.endTrace(record.traceId, {
+            endTime: traceStartTime + navDurationMs,
+            status: 'ok',
+            metadata: { origin: 'ssr' },
+        })
+    }
+
     // Expose registries globally so Vite transform shims can reach them.
     // This must happen synchronously — before any component setup() runs —
     // so that shims injected by the Vite transforms find the registry already
@@ -86,6 +159,9 @@ export default defineNuxtPlugin(() => {
         if (config.traceViewer) {
             setupComponentInstrumentation(nuxtApp)
             setupFetchInstrumentation(nuxtApp)
+            // Pick up SSR spans injected into the HTML by the Nitro plugin and
+            // merge them into the client traceStore as a standalone SSR trace.
+            mergeSsrSpans()
         }
 
         // Always clear any previous registry to avoid cross-project state

--- a/src/runtime/tracing/trace.ts
+++ b/src/runtime/tracing/trace.ts
@@ -1,5 +1,6 @@
 export type SpanType =
     | 'render'
+    | 'component'
     | 'transition'
     | 'fetch'
     | 'composable'

--- a/tests/nitro/fetch-capture.test.ts
+++ b/tests/nitro/fetch-capture.test.ts
@@ -2,10 +2,14 @@ import { describe, it, expect, beforeAll, vi } from 'vitest'
 
 let requestHook: (event: Record<string, unknown>) => void
 let afterResponseHook: (event: Record<string, unknown>) => void
+let renderHtmlHook: (html: { bodyAppend: string[] }, ctx: { event: Record<string, unknown> }) => void
+
 const setResponseHeader = vi.fn()
+const getRequestURL = vi.fn().mockReturnValue(new URL('http://localhost/dashboard'))
 
 vi.mock('h3', () => ({
     setResponseHeader,
+    getRequestURL,
 }))
 
 beforeAll(async () => {
@@ -16,34 +20,53 @@ beforeAll(async () => {
             hook(name: string, handler: unknown) {
                 if (name === 'request') requestHook = handler as typeof requestHook
                 if (name === 'afterResponse') afterResponseHook = handler as typeof afterResponseHook
+                if (name === 'render:html') renderHtmlHook = handler as typeof renderHtmlHook
             },
         },
     })
 })
 
+function makeEvent(): { context: Record<string, unknown>; node?: { req?: { method?: string } } } {
+    return { context: {} }
+}
+
 describe('fetch-capture nitro plugin', () => {
-    it('stamps event.__ssrFetchStart with a numeric timestamp on request', () => {
-        const event: Record<string, unknown> = {}
+    it('stamps event.context.__ssrFetchStart with a numeric timestamp on request', () => {
+        const event = makeEvent()
 
-        requestHook(event)
+        requestHook(event as unknown as Record<string, unknown>)
 
-        expect(typeof event.__ssrFetchStart).toBe('number')
-        expect(event.__ssrFetchStart as number).toBeGreaterThan(0)
+        expect(typeof event.context.__ssrFetchStart).toBe('number')
+        expect(event.context.__ssrFetchStart as number).toBeGreaterThan(0)
+    })
+
+    it('assigns a string requestId to event.context.__observatoryRequestId', () => {
+        const event = makeEvent()
+
+        requestHook(event as unknown as Record<string, unknown>)
+
+        expect(typeof event.context.__observatoryRequestId).toBe('string')
+        expect((event.context.__observatoryRequestId as string).length).toBeGreaterThan(0)
     })
 
     it('sets the x-observatory-ssr-ms response header after a response', () => {
-        const event: Record<string, unknown> = { __ssrFetchStart: performance.now() - 50 }
+        const event = makeEvent()
 
-        afterResponseHook(event)
+        requestHook(event as unknown as Record<string, unknown>)
+        const callsBefore = setResponseHeader.mock.calls.length
+        afterResponseHook(event as unknown as Record<string, unknown>)
 
-        expect(setResponseHeader).toHaveBeenCalledWith(event, 'x-observatory-ssr-ms', expect.any(String))
-        expect(Number(setResponseHeader.mock.calls[0][2])).toBeGreaterThanOrEqual(0)
+        expect(setResponseHeader.mock.calls.length).toBeGreaterThan(callsBefore)
+        const lastCall = setResponseHeader.mock.calls.at(-1)!
+        expect(lastCall[1]).toBe('x-observatory-ssr-ms')
+        expect(Number(lastCall[2])).toBeGreaterThanOrEqual(0)
     })
 
     it('the elapsed ms in the header is a non-negative integer', () => {
-        const event: Record<string, unknown> = { __ssrFetchStart: performance.now() - 100 }
+        const event = makeEvent()
 
-        afterResponseHook(event)
+        requestHook(event as unknown as Record<string, unknown>)
+        afterResponseHook(event as unknown as Record<string, unknown>)
 
         const ms = Number(setResponseHeader.mock.calls.at(-1)?.[2])
 
@@ -52,11 +75,41 @@ describe('fetch-capture nitro plugin', () => {
     })
 
     it('does NOT set the header when the event has no __ssrFetchStart', () => {
-        const event: Record<string, unknown> = {}
+        const event = makeEvent()
+        // No requestHook called — context is empty
 
         const callsBefore = setResponseHeader.mock.calls.length
-        afterResponseHook(event)
+        afterResponseHook(event as unknown as Record<string, unknown>)
 
         expect(setResponseHeader.mock.calls).toHaveLength(callsBefore)
+    })
+
+    it('injects a JSON script tag into html.bodyAppend on render:html', () => {
+        const event = makeEvent()
+
+        requestHook(event as unknown as Record<string, unknown>)
+
+        const html = { bodyAppend: [] as string[] }
+        renderHtmlHook(html, { event: event as unknown as Record<string, unknown> })
+
+        expect(html.bodyAppend).toHaveLength(1)
+        expect(html.bodyAppend[0]).toContain('<script id="__observatory_ssr_spans__"')
+        expect(html.bodyAppend[0]).toContain('type="application/json"')
+
+        // The JSON must be parseable and contain a traceId and spans array.
+        const match = html.bodyAppend[0].match(/>(.+)<\/script>/)
+        const parsed = JSON.parse(match![1])
+        expect(typeof parsed.traceId).toBe('string')
+        expect(Array.isArray(parsed.spans)).toBe(true)
+        expect(parsed.spans.length).toBeGreaterThan(0)
+    })
+
+    it('does nothing in render:html when the event has no requestId', () => {
+        const event = makeEvent() // no requestHook call
+
+        const html = { bodyAppend: [] as string[] }
+        renderHtmlHook(html, { event: event as unknown as Record<string, unknown> })
+
+        expect(html.bodyAppend).toHaveLength(0)
     })
 })


### PR DESCRIPTION
This pull request introduces server-side rendering (SSR) trace collection and visualization into the trace viewer, enabling developers to see SSR request traces alongside client-side navigations. The main changes include new logic for collecting SSR traces on the server, injecting them into rendered HTML, merging them into the client-side trace store, and enhancing the trace viewer UI with a new render summary panel.

**SSR Trace Collection and Injection:**

- Added a server-side trace store (`ssr-trace-store.ts`) that collects SSR spans per request, including navigation and fetch spans, and finalizes them for injection.
- Updated the Nitro plugin (`fetch-capture.ts`) to:
  - Create and manage SSR trace records for each request.
  - Inject the completed SSR trace as inline JSON into the rendered HTML.
  - Annotate responses with SSR timing headers for easier identification.
- Ensured the plugin is registered when SSR tracing is enabled.

**Client-Side Trace Integration:**

- Enhanced the client plugin to read the injected SSR trace JSON and merge its spans into the client-side `traceStore`, so SSR traces appear in the trace viewer alongside client navigations.

**Trace Viewer UI Improvements:**

- Added a new "Render Summary" panel to the trace viewer:
  - Aggregates render spans by component, showing mount/re-render counts and timings.
  - Allows users to highlight all spans for a component by clicking its row.
  - Provides UI controls for expanding/collapsing and clearing highlights.
  - Includes new styles for the summary panel and highlighted spans. [[1]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R22-R23) [[2]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R63-R140) [[3]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R220) [[4]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R275-R281) [[5]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24L346-R439) [[6]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R450-R496) [[7]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R818-R901)

---

### SSR Trace Collection and Injection

* Implemented a per-request SSR trace collector (`ssr-trace-store.ts`) that records navigation and fetch spans, and finalizes them for injection into HTML.
* Updated the Nitro plugin to handle SSR trace lifecycle: creating records on request, annotating responses, and injecting traces into HTML via a script tag.
* Modified module registration logic to ensure the SSR tracing plugin is included when required.

### Client-Side Trace Integration

* Enhanced the client plugin to extract and merge SSR traces from injected JSON into the client trace store, so SSR traces are visible in the trace viewer UI.

### Trace Viewer UI Improvements

* Added a "Render Summary" panel to the trace viewer, aggregating render spans by component, supporting highlighting, and providing new UI/UX for exploring render performance. [[1]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R22-R23) [[2]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R63-R140) [[3]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R220) [[4]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R275-R281) [[5]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24L346-R439) [[6]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R450-R496) [[7]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R818-R901)