### PR TITLE
Add instrumentation tests for components, fetch, routes, and tracing

### DIFF
--- a/tests/nitro/ssr-trace-store.test.ts
+++ b/tests/nitro/ssr-trace-store.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest'
+import {
+    createSsrRecord,
+    addSsrFetchSpan,
+    drainSsrRecord,
+} from '@observatory/runtime/nitro/ssr-trace-store'
+
+// Each test uses a unique requestId so module-level `pending` Map state does
+// not bleed between tests even if a record is never drained.
+let idCounter = 0
+function uniqueId() {
+    return `test-req-${++idCounter}`
+}
+
+describe('createSsrRecord', () => {
+    it('returns a record with the correct name based on route', () => {
+        const id = uniqueId()
+        const record = createSsrRecord(id, '/dashboard', 'GET')
+
+        expect(record.name).toBe('ssr:/dashboard')
+    })
+
+    it('returns a record with a non-empty traceId', () => {
+        const id = uniqueId()
+        const record = createSsrRecord(id, '/home', 'GET')
+
+        expect(record.traceId).toBeTruthy()
+        expect(typeof record.traceId).toBe('string')
+    })
+
+    it('pre-populates a single ssr:navigation span', () => {
+        const id = uniqueId()
+        const record = createSsrRecord(id, '/home', 'POST')
+
+        expect(record.spans).toHaveLength(1)
+        expect(record.spans[0].name).toBe('ssr:navigation')
+        expect(record.spans[0].type).toBe('navigation')
+        expect(record.spans[0].status).toBe('active')
+        expect(record.spans[0].startTime).toBe(0)
+    })
+
+    it('stores route and method in the navigation span metadata', () => {
+        const id = uniqueId()
+        const record = createSsrRecord(id, '/products', 'GET')
+
+        expect(record.spans[0].metadata).toMatchObject({
+            origin: 'ssr',
+            route: '/products',
+            method: 'GET',
+        })
+    })
+
+    it('makes the record retrievable by drainSsrRecord', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/test', 'GET')
+        const drained = drainSsrRecord(id, 100)
+
+        expect(drained).toBeDefined()
+    })
+})
+
+describe('addSsrFetchSpan', () => {
+    it('appends a fetch span to an existing record', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        addSsrFetchSpan(id, { url: '/api/data', method: 'GET', startMs: 10, endMs: 50 })
+
+        const record = drainSsrRecord(id, 100)
+
+        expect(record?.spans).toHaveLength(2)
+
+        const fetchSpan = record?.spans[1]
+
+        expect(fetchSpan?.type).toBe('fetch')
+        expect(fetchSpan?.name).toBe('/api/data')
+    })
+
+    it('sets correct startTime, endTime, and durationMs on the span', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        addSsrFetchSpan(id, { url: '/api/users', method: 'POST', startMs: 20, endMs: 80 })
+
+        const record = drainSsrRecord(id, 200)
+        const span = record?.spans[1]
+
+        expect(span?.startTime).toBe(20)
+        expect(span?.endTime).toBe(80)
+        expect(span?.durationMs).toBe(60)
+    })
+
+    it('sets status ok when error flag is not set', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        addSsrFetchSpan(id, { url: '/api/ok', method: 'GET', startMs: 0, endMs: 30 })
+
+        const record = drainSsrRecord(id, 100)
+
+        expect(record?.spans[1]?.status).toBe('ok')
+    })
+
+    it('sets status error when error flag is true', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        addSsrFetchSpan(id, { url: '/api/fail', method: 'GET', startMs: 0, endMs: 30, error: true })
+
+        const record = drainSsrRecord(id, 100)
+
+        expect(record?.spans[1]?.status).toBe('error')
+    })
+
+    it('stores statusCode in span metadata when provided', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        addSsrFetchSpan(id, { url: '/api/data', method: 'GET', startMs: 0, endMs: 20, statusCode: 201 })
+
+        const record = drainSsrRecord(id, 100)
+
+        expect(record?.spans[1]?.metadata?.statusCode).toBe(201)
+    })
+
+    it('is a no-op for an unknown requestId', () => {
+        expect(() => {
+            addSsrFetchSpan('unknown-request-id', { url: '/api/x', method: 'GET', startMs: 0, endMs: 10 })
+        }).not.toThrow()
+    })
+
+    it('durationMs is 0 when endMs is before startMs', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        addSsrFetchSpan(id, { url: '/api/data', method: 'GET', startMs: 100, endMs: 50 })
+
+        const record = drainSsrRecord(id, 200)
+
+        expect(record?.spans[1]?.durationMs).toBe(0)
+    })
+})
+
+describe('drainSsrRecord', () => {
+    it('closes the navigation span with endTime equal to durationMs', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        const record = drainSsrRecord(id, 350)
+        const navSpan = record?.spans[0]
+
+        expect(navSpan?.endTime).toBe(350)
+        expect(navSpan?.durationMs).toBe(350)
+        expect(navSpan?.status).toBe('ok')
+    })
+
+    it('removes the record from the pending map — second call returns undefined', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        drainSsrRecord(id, 100)
+
+        expect(drainSsrRecord(id, 100)).toBeUndefined()
+    })
+
+    it('returns undefined for an unknown requestId', () => {
+        expect(drainSsrRecord('totally-unknown', 100)).toBeUndefined()
+    })
+
+    it('returns all previously added fetch spans alongside the navigation span', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+        addSsrFetchSpan(id, { url: '/api/a', method: 'GET', startMs: 5, endMs: 20 })
+        addSsrFetchSpan(id, { url: '/api/b', method: 'POST', startMs: 25, endMs: 40 })
+        const record = drainSsrRecord(id, 100)
+
+        expect(record?.spans).toHaveLength(3)
+    })
+})

--- a/tests/runtime/instrumentation/asyncData.test.ts
+++ b/tests/runtime/instrumentation/asyncData.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useTracedAsyncData } from '@observatory/runtime/instrumentation/asyncData'
+import { traceStore } from '@observatory/runtime/tracing/traceStore'
+
+const TRACE_CONTEXT_KEY = '__observatory_trace_context__'
+
+const BASE_META = {
+    key: 'test-key',
+    file: '/src/pages/index.vue',
+    line: 10,
+    originalFn: 'useFetch',
+}
+
+beforeEach(() => {
+    traceStore.clear()
+    delete (globalThis as Record<string, unknown>)[TRACE_CONTEXT_KEY]
+})
+
+function getSpans() {
+    return traceStore.getAllTraces().flatMap((t) => t.spans)
+}
+
+describe('useTracedAsyncData', () => {
+    describe('getNormalizedKey (tested indirectly via span metadata)', () => {
+        it('uses the string key as span metadata.key when it is non-empty', async () => {
+            const handler = vi.fn().mockResolvedValue('data')
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            await useTracedAsyncData(originalFn, ['users', handler], 1, 'users', BASE_META)
+
+            expect(getSpans()[0].metadata?.key).toBe('users')
+        })
+
+        it('falls back to "useAsyncData" when the key is not a string', async () => {
+            const handler = vi.fn().mockResolvedValue('data')
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            await useTracedAsyncData(originalFn, [42, handler], 1, 42, BASE_META)
+
+            expect(getSpans()[0].metadata?.key).toBe('useAsyncData')
+        })
+
+        it('falls back to "useAsyncData" when the key is an empty string', async () => {
+            const handler = vi.fn().mockResolvedValue('data')
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            await useTracedAsyncData(originalFn, ['', handler], 1, '', BASE_META)
+
+            expect(getSpans()[0].metadata?.key).toBe('useAsyncData')
+        })
+    })
+
+    describe('handler wrapping on success', () => {
+        it('creates a fetch span when the handler is invoked', async () => {
+            const handler = vi.fn().mockResolvedValue({ users: [] })
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            await useTracedAsyncData(originalFn, ['users', handler], 1, 'users', BASE_META)
+
+            const spans = getSpans()
+
+            expect(spans).toHaveLength(1)
+            expect(spans[0].type).toBe('fetch')
+        })
+
+        it('ends the span with status ok on resolve', async () => {
+            const handler = vi.fn().mockResolvedValue('result')
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            await useTracedAsyncData(originalFn, ['key', handler], 1, 'key', BASE_META)
+
+            expect(getSpans()[0].status).toBe('ok')
+        })
+
+        it('passes through the resolved value to the original function', async () => {
+            const payload = { id: 1 }
+            const handler = vi.fn().mockResolvedValue(payload)
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            const result = await useTracedAsyncData(originalFn, ['data', handler], 1, 'data', BASE_META)
+
+            expect(result).toEqual(payload)
+        })
+
+        it('includes file and line in span metadata', async () => {
+            const handler = vi.fn().mockResolvedValue(null)
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            await useTracedAsyncData(originalFn, ['k', handler], 1, 'k', BASE_META)
+
+            const span = getSpans()[0]
+
+            expect(span.metadata?.file).toBe(BASE_META.file)
+            expect(span.metadata?.line).toBe(BASE_META.line)
+        })
+    })
+
+    describe('handler wrapping on failure', () => {
+        it('ends span with error status when the handler rejects', async () => {
+            const handler = vi.fn().mockRejectedValue(new Error('fetch failed'))
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) =>
+                wrappedHandler().catch(() => {}),
+            )
+
+            await useTracedAsyncData(originalFn, ['key', handler], 1, 'key', BASE_META)
+
+            expect(getSpans()[0].status).toBe('error')
+        })
+
+        it('records the error message in span metadata', async () => {
+            const handler = vi.fn().mockRejectedValue(new Error('something broke'))
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) =>
+                wrappedHandler().catch(() => {}),
+            )
+
+            await useTracedAsyncData(originalFn, ['key', handler], 1, 'key', BASE_META)
+
+            expect(getSpans()[0].metadata?.errorMessage).toBe('something broke')
+        })
+
+        it('re-throws the error after ending the span', async () => {
+            const originalError = new Error('rethrown')
+            const handler = vi.fn().mockRejectedValue(originalError)
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) => wrappedHandler())
+
+            await expect(useTracedAsyncData(originalFn, ['key', handler], 1, 'key', BASE_META)).rejects.toBe(
+                originalError,
+            )
+
+            expect(getSpans()[0].status).toBe('error')
+        })
+    })
+
+    describe('passthrough cases', () => {
+        it('calls originalFn unchanged when the value at handlerIndex is not a function', () => {
+            const originalFn = vi.fn().mockReturnValue('direct')
+            const result = useTracedAsyncData(originalFn, ['key', 'not-a-function'], 1, 'key', BASE_META)
+
+            expect(originalFn).toHaveBeenCalledWith('key', 'not-a-function')
+            expect(result).toBe('direct')
+            expect(getSpans()).toHaveLength(0)
+        })
+
+        it('calls originalFn with the modified args array', async () => {
+            const handler = vi.fn().mockResolvedValue(null)
+            const originalFn = vi.fn().mockImplementation((_key, wrappedHandler) =>
+                wrappedHandler().catch(() => {}),
+            )
+
+            await useTracedAsyncData(originalFn, ['key', handler], 1, 'key', BASE_META)
+
+            expect(originalFn).toHaveBeenCalledTimes(1)
+
+            // The second argument passed to originalFn should be the wrapped handler, not the original
+            const passedHandler = originalFn.mock.calls[0][1]
+
+            expect(passedHandler).not.toBe(handler)
+            expect(typeof passedHandler).toBe('function')
+        })
+    })
+})

--- a/tests/runtime/instrumentation/component.test.ts
+++ b/tests/runtime/instrumentation/component.test.ts
@@ -1,0 +1,255 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setupComponentInstrumentation } from '@observatory/runtime/instrumentation/component'
+import { traceStore } from '@observatory/runtime/tracing/traceStore'
+import type { NuxtApp } from '#app'
+import type { ComponentPublicInstance } from 'vue'
+
+const TRACE_CONTEXT_KEY = '__observatory_trace_context__'
+
+// Build a minimal fake ComponentPublicInstance sufficient for the instrumentation hooks.
+function fakeInstance(opts: {
+    __name?: string
+    name?: string
+    __file?: string
+    uid?: number
+} = {}): ComponentPublicInstance {
+    return {
+        $: {
+            type: {
+                __name: opts.__name,
+                name: opts.name,
+                __file: opts.__file,
+            },
+            uid: opts.uid ?? 1,
+        },
+    } as unknown as ComponentPublicInstance
+}
+
+// Build a minimal NuxtApp stub and capture the installed mixin.
+function makeMockApp() {
+    let installedMixin: Record<string, (this: ComponentPublicInstance) => void> = {}
+    const vueApp = {
+        // Each invocation captures the mixin so tests can call hooks manually.
+        mixin: vi.fn((m: Record<string, (this: ComponentPublicInstance) => void>) => {
+            installedMixin = m
+        }),
+    }
+    const nuxtApp = { vueApp } as unknown as NuxtApp
+
+    return { nuxtApp, vueApp, getMixin: () => installedMixin }
+}
+
+function getSpans() {
+    return traceStore.getAllTraces().flatMap((t) => t.spans)
+}
+
+beforeEach(() => {
+    traceStore.clear()
+    delete (globalThis as Record<string, unknown>)[TRACE_CONTEXT_KEY]
+})
+
+describe('setupComponentInstrumentation', () => {
+    describe('mixin installation guard', () => {
+        it('installs the mixin exactly once for the same app instance', () => {
+            const { nuxtApp, vueApp } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            setupComponentInstrumentation(nuxtApp)
+
+            expect(vueApp.mixin).toHaveBeenCalledTimes(1)
+        })
+
+        it('installs the mixin independently for different app instances', () => {
+            const { nuxtApp: app1, vueApp: vueApp1 } = makeMockApp()
+            const { nuxtApp: app2, vueApp: vueApp2 } = makeMockApp()
+            setupComponentInstrumentation(app1)
+            setupComponentInstrumentation(app2)
+
+            expect(vueApp1.mixin).toHaveBeenCalledTimes(1)
+            expect(vueApp2.mixin).toHaveBeenCalledTimes(1)
+        })
+    })
+
+    describe('getComponentName resolution (tested via span metadata)', () => {
+        it('uses __name when available', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'NamedComp', __file: '/src/NamedComp.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            const span = getSpans().find((s) => s.name === 'component:render')
+
+            expect(span?.metadata?.componentName).toBe('NamedComp')
+        })
+
+        it('falls back to name when __name is absent', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ name: 'FallbackComp', __file: '/src/Fallback.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            const span = getSpans().find((s) => s.name === 'component:render')
+
+            expect(span?.metadata?.componentName).toBe('FallbackComp')
+        })
+
+        it('derives name from __file stem when neither __name nor name are set', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __file: '/src/components/MyWidget.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            const span = getSpans().find((s) => s.name === 'component:render')
+
+            expect(span?.metadata?.componentName).toBe('MyWidget')
+        })
+
+        it('uses empty string as name when __file ends with a path separator', () => {
+            // getComponentName returns '' when the __file stem is empty (e.g. '/src/').
+            // The AnonymousComponent fallback is only reachable when __file is falsy,
+            // which is mutually exclusive with shouldTrack returning true — so it
+            // cannot be exercised via span metadata.
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __file: '/src/' })
+            ;(instance.$.type as Record<string, unknown>).__name = undefined
+            ;(instance.$.type as Record<string, unknown>).name = undefined
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            const span = getSpans().find((s) => s.name === 'component:render')
+
+            expect(span?.metadata?.componentName).toBe('')
+        })
+    })
+
+    describe('shouldTrack filtering', () => {
+        it('does not emit spans for components without a __file', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'Headless' }) // no __file
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            expect(getSpans()).toHaveLength(0)
+        })
+
+        it('does not emit spans for node_modules components', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __file: '/node_modules/some-lib/Button.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            expect(getSpans()).toHaveLength(0)
+        })
+
+        it('emits spans for project components with a valid __file', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'MyComp', __file: '/src/MyComp.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            expect(getSpans().length).toBeGreaterThan(0)
+        })
+    })
+
+    describe('mount lifecycle hooks', () => {
+        it('emits a component:render span on mount', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'App', __file: '/src/App.vue', uid: 5 })
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            const renderSpan = getSpans().find((s) => s.name === 'component:render')
+
+            expect(renderSpan).toBeDefined()
+            expect(renderSpan?.metadata?.lifecycle).toBe('render:mount')
+            expect(renderSpan?.metadata?.uid).toBe(5)
+            expect(renderSpan?.status).toBe('ok')
+        })
+
+        it('emits a component:mounted span on mount', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'App', __file: '/src/App.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeMount?.call(instance)
+            mixin.mounted?.call(instance)
+
+            const lifecycleSpan = getSpans().find((s) => s.name === 'component:mounted')
+
+            expect(lifecycleSpan).toBeDefined()
+            expect(lifecycleSpan?.metadata?.lifecycle).toBe('mounted')
+            expect(lifecycleSpan?.status).toBe('ok')
+        })
+
+        it('does not emit a render span when mounted is called without a prior beforeMount', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'Late', __file: '/src/Late.vue' })
+            const mixin = getMixin()
+
+            // skip beforeMount → no renderStartTime
+            mixin.mounted?.call(instance)
+
+            const renderSpan = getSpans().find((s) => s.name === 'component:render')
+
+            expect(renderSpan).toBeUndefined()
+        })
+    })
+
+    describe('update lifecycle hooks', () => {
+        it('emits component:render with render:update lifecycle on update', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'Counter', __file: '/src/Counter.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeUpdate?.call(instance)
+            mixin.updated?.call(instance)
+
+            const renderSpan = getSpans().find((s) => s.metadata?.lifecycle === 'render:update')
+
+            expect(renderSpan).toBeDefined()
+            expect(renderSpan?.status).toBe('ok')
+        })
+
+        it('emits component:updated span on update', () => {
+            const { nuxtApp, getMixin } = makeMockApp()
+            setupComponentInstrumentation(nuxtApp)
+            const instance = fakeInstance({ __name: 'Counter', __file: '/src/Counter.vue' })
+            const mixin = getMixin()
+
+            mixin.beforeUpdate?.call(instance)
+            mixin.updated?.call(instance)
+
+            const lifecycleSpan = getSpans().find((s) => s.name === 'component:updated')
+
+            expect(lifecycleSpan).toBeDefined()
+            expect(lifecycleSpan?.metadata?.lifecycle).toBe('updated')
+        })
+    })
+})

--- a/tests/runtime/instrumentation/fetch.test.ts
+++ b/tests/runtime/instrumentation/fetch.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setupFetchInstrumentation } from '@observatory/runtime/instrumentation/fetch'
+import { traceStore } from '@observatory/runtime/tracing/traceStore'
+import type { NuxtApp } from '#app'
+
+const TRACE_CONTEXT_KEY = '__observatory_trace_context__'
+const WRAPPED_FLAG = '__observatory_wrapped_fetch__'
+
+function makeNuxtApp(fetchImpl?: (...args: unknown[]) => Promise<unknown>) {
+    return {
+        $fetch: fetchImpl ?? vi.fn().mockResolvedValue({}),
+    } as unknown as NuxtApp
+}
+
+beforeEach(() => {
+    traceStore.clear()
+    delete (globalThis as Record<string, unknown>)[TRACE_CONTEXT_KEY]
+})
+
+function getSpans() {
+    return traceStore.getAllTraces().flatMap((t) => t.spans)
+}
+
+describe('setupFetchInstrumentation', () => {
+    describe('span creation on successful fetch', () => {
+        it('creates a fetch span with status ok after resolution', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({ ok: true }))
+            setupFetchInstrumentation(nuxtApp)
+
+            await (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/users')
+
+            const spans = getSpans()
+
+            expect(spans).toHaveLength(1)
+            expect(spans[0].status).toBe('ok')
+            expect(spans[0].type).toBe('fetch')
+        })
+
+        it('records the span name as $fetch', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+            await (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/test')
+
+            expect(getSpans()[0].name).toBe('$fetch')
+        })
+
+        it('returns the resolved value unchanged', async () => {
+            const payload = { id: 1, name: 'Alice' }
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue(payload))
+            setupFetchInstrumentation(nuxtApp)
+
+            const result = await (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/user')
+
+            expect(result).toEqual(payload)
+        })
+    })
+
+    describe('span creation on failed fetch', () => {
+        it('ends span with error status when the original fetch rejects', async () => {
+            const error = new Error('Network Error')
+            const nuxtApp = makeNuxtApp(vi.fn().mockRejectedValue(error))
+            setupFetchInstrumentation(nuxtApp)
+
+            await expect(
+                (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/fail'),
+            ).rejects.toThrow('Network Error')
+
+            const spans = getSpans()
+
+            expect(spans[0].status).toBe('error')
+        })
+
+        it('records response.status as statusCode in span metadata', async () => {
+            const error = { response: { status: 404 } }
+            const nuxtApp = makeNuxtApp(vi.fn().mockRejectedValue(error))
+            setupFetchInstrumentation(nuxtApp)
+
+            await expect(
+                (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/missing'),
+            ).rejects.toBeDefined()
+
+            expect(getSpans()[0].metadata?.statusCode).toBe(404)
+        })
+
+        it('records statusCode field from error object', async () => {
+            const error = { statusCode: 500 }
+            const nuxtApp = makeNuxtApp(vi.fn().mockRejectedValue(error))
+            setupFetchInstrumentation(nuxtApp)
+
+            await expect(
+                (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/crash'),
+            ).rejects.toBeDefined()
+
+            expect(getSpans()[0].metadata?.statusCode).toBe(500)
+        })
+
+        it('records status field from error object', async () => {
+            const error = { status: 403 }
+            const nuxtApp = makeNuxtApp(vi.fn().mockRejectedValue(error))
+            setupFetchInstrumentation(nuxtApp)
+
+            await expect(
+                (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/forbidden'),
+            ).rejects.toBeDefined()
+
+            expect(getSpans()[0].metadata?.statusCode).toBe(403)
+        })
+
+        it('re-throws the original error after ending the span', async () => {
+            const originalError = new Error('original')
+            const nuxtApp = makeNuxtApp(vi.fn().mockRejectedValue(originalError))
+            setupFetchInstrumentation(nuxtApp)
+
+            await expect(
+                (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)('/api/err'),
+            ).rejects.toBe(originalError)
+        })
+    })
+
+    describe('URL resolution (resolveUrl)', () => {
+        async function callWith(input: unknown, nuxtApp: NuxtApp) {
+            await (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)(input)
+        }
+
+        it('records a plain string URL', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+            await callWith('/api/items', nuxtApp)
+
+            expect(getSpans()[0].metadata?.url).toBe('/api/items')
+        })
+
+        it('extracts url from a Request-like object', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+            await callWith({ url: '/api/resource' }, nuxtApp)
+
+            expect(getSpans()[0].metadata?.url).toBe('/api/resource')
+        })
+
+        it('converts null/undefined input to an empty string URL', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+            await callWith(null, nuxtApp)
+
+            expect(getSpans()[0].metadata?.url).toBe('')
+        })
+    })
+
+    describe('method resolution (resolveMethod)', () => {
+        async function callWith(input: unknown, options: Record<string, unknown>, nuxtApp: NuxtApp) {
+            await (nuxtApp.$fetch as unknown as (...a: unknown[]) => Promise<unknown>)(input, options)
+        }
+
+        it('uses method from options and uppercases it', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+            await callWith('/api/data', { method: 'post' }, nuxtApp)
+
+            expect(getSpans()[0].metadata?.method).toBe('POST')
+        })
+
+        it('falls back to GET when no method is provided', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+            await callWith('/api/data', {}, nuxtApp)
+
+            expect(getSpans()[0].metadata?.method).toBe('GET')
+        })
+
+        it('reads method from a Request-like first argument', async () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+            await callWith({ url: '/api/x', method: 'DELETE' }, {}, nuxtApp)
+
+            expect(getSpans()[0].metadata?.method).toBe('DELETE')
+        })
+    })
+
+    describe('double-wrap protection', () => {
+        it('does not re-wrap an already-wrapped $fetch', () => {
+            const original = vi.fn().mockResolvedValue({})
+            const nuxtApp = makeNuxtApp(original)
+            setupFetchInstrumentation(nuxtApp)
+
+            const wrappedOnce = nuxtApp.$fetch
+
+            setupFetchInstrumentation(nuxtApp)
+
+            // The reference should not change on the second call
+            expect(nuxtApp.$fetch).toBe(wrappedOnce)
+        })
+
+        it('marks the wrapped function with the sentinel flag', () => {
+            const nuxtApp = makeNuxtApp(vi.fn().mockResolvedValue({}))
+            setupFetchInstrumentation(nuxtApp)
+
+            expect((nuxtApp.$fetch as unknown as Record<string, unknown>)[WRAPPED_FLAG]).toBe(true)
+        })
+    })
+
+    describe('guard against missing $fetch', () => {
+        it('is a no-op when nuxtApp.$fetch is undefined', () => {
+            const nuxtApp = { $fetch: undefined } as unknown as NuxtApp
+
+            expect(() => setupFetchInstrumentation(nuxtApp)).not.toThrow()
+            expect(getSpans()).toHaveLength(0)
+        })
+    })
+})

--- a/tests/runtime/instrumentation/route.test.ts
+++ b/tests/runtime/instrumentation/route.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setupRouteInstrumentation } from '@observatory/runtime/instrumentation/route'
+import { traceStore } from '@observatory/runtime/tracing/traceStore'
+import type { NuxtApp } from '#app'
+
+const TRACE_CONTEXT_KEY = '__observatory_trace_context__'
+
+// Build a minimal NuxtApp stub that records hook registrations and allows tests
+// to trigger them manually.
+function createMockApp(currentPath: string = '/home') {
+    const hooks: Record<string, Array<() => void>> = {}
+    const carrier = {}
+
+    const nuxtApp = {
+        hook: (event: string, cb: () => void) => {
+            hooks[event] ??= []
+            hooks[event].push(cb)
+        },
+    } as unknown as NuxtApp
+
+    function trigger(event: string) {
+        hooks[event]?.forEach((cb) => cb())
+    }
+
+    const options = {
+        getCurrentPath: () => currentPath,
+        carrier,
+    }
+
+    return { nuxtApp, trigger, carrier, options }
+}
+
+beforeEach(() => {
+    traceStore.clear()
+    delete (globalThis as Record<string, unknown>)[TRACE_CONTEXT_KEY]
+})
+
+describe('setupRouteInstrumentation', () => {
+    describe('page:start', () => {
+        it('creates a trace named route:<path>', () => {
+            const { nuxtApp, trigger, options } = createMockApp('/dashboard')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+
+            const traces = traceStore.getAllTraces()
+
+            expect(traces).toHaveLength(1)
+            expect(traces[0].name).toBe('route:/dashboard')
+        })
+
+        it('sets kind metadata on the new trace', () => {
+            const { nuxtApp, trigger, options } = createMockApp('/shop')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+
+            const trace = traceStore.getAllTraces()[0]
+
+            expect(trace.metadata?.kind).toBe('route-navigation')
+            expect(trace.metadata?.route).toBe('/shop')
+        })
+
+        it('stores the traceId on the carrier', () => {
+            const { nuxtApp, trigger, options, carrier } = createMockApp('/home')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+
+            const traceId = traceStore.getAllTraces()[0].id
+
+            expect((carrier as Record<string, unknown>)[TRACE_CONTEXT_KEY]).toBeDefined()
+            expect(
+                ((carrier as Record<string, unknown>)[TRACE_CONTEXT_KEY] as { currentTraceId?: string })?.currentTraceId,
+            ).toBe(traceId)
+        })
+
+        it('cancels the previous trace when a new navigation starts', () => {
+            const { nuxtApp, trigger, options } = createMockApp('/home')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+
+            const firstTraceId = traceStore.getAllTraces()[0].id
+
+            trigger('page:start')
+
+            const firstTrace = traceStore.getTrace(firstTraceId)
+
+            expect(firstTrace?.status).toBe('cancelled')
+            expect(firstTrace?.endTime).toBeDefined()
+            expect(traceStore.getAllTraces()).toHaveLength(2)
+        })
+    })
+
+    describe('page:finish', () => {
+        it('ends the active trace with status ok', () => {
+            const { nuxtApp, trigger, options } = createMockApp('/home')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+            trigger('page:finish')
+
+            const trace = traceStore.getAllTraces()[0]
+
+            expect(trace.status).toBe('ok')
+            expect(trace.endTime).toBeDefined()
+        })
+
+        it('clears the currentTraceId from the carrier', () => {
+            const { nuxtApp, trigger, options, carrier } = createMockApp('/home')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+            trigger('page:finish')
+
+            const ctx = (carrier as Record<string, unknown>)[TRACE_CONTEXT_KEY] as
+                | { currentTraceId?: string }
+                | undefined
+
+            expect(ctx?.currentTraceId).toBeUndefined()
+        })
+
+        it('is a no-op when called without a prior page:start', () => {
+            const { nuxtApp, trigger, options } = createMockApp('/home')
+            setupRouteInstrumentation(nuxtApp, options)
+
+            expect(() => trigger('page:finish')).not.toThrow()
+            expect(traceStore.getAllTraces()).toHaveLength(0)
+        })
+    })
+
+    describe('getCurrentPath fallback', () => {
+        it('falls back to "/" when the path is an empty string', () => {
+            const { nuxtApp, trigger, options } = createMockApp('')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+
+            expect(traceStore.getAllTraces()[0].name).toBe('route:/')
+        })
+    })
+
+    describe('full navigation lifecycle', () => {
+        it('start → finish creates a completed trace', () => {
+            const { nuxtApp, trigger, options } = createMockApp('/about')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+            trigger('page:finish')
+
+            const traces = traceStore.getAllTraces()
+
+            expect(traces).toHaveLength(1)
+            expect(traces[0].status).toBe('ok')
+        })
+
+        it('two consecutive navigations each get their own completed trace', () => {
+            const { nuxtApp, trigger, options } = createMockApp('/page-a')
+            setupRouteInstrumentation(nuxtApp, options)
+            trigger('page:start')
+            trigger('page:finish')
+            trigger('page:start')
+            trigger('page:finish')
+
+            const traces = traceStore.getAllTraces()
+            
+            expect(traces).toHaveLength(2)
+            expect(traces.every((t) => t.status === 'ok')).toBe(true)
+        })
+    })
+})

--- a/tests/runtime/tracing/context.test.ts
+++ b/tests/runtime/tracing/context.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { setCurrentTraceId, getCurrentTraceId } from '@observatory/runtime/tracing/context'
+
+const TRACE_CONTEXT_KEY = '__observatory_trace_context__'
+
+interface Carrier {
+    [TRACE_CONTEXT_KEY]?: { currentTraceId?: string }
+}
+
+afterEach(() => {
+    // Prevent globalThis pollution across tests
+    delete (globalThis as Record<string, unknown>)[TRACE_CONTEXT_KEY]
+})
+
+describe('setCurrentTraceId / getCurrentTraceId', () => {
+    it('stores and retrieves a traceId on globalThis by default', () => {
+        setCurrentTraceId('trace-abc')
+
+        expect(getCurrentTraceId()).toBe('trace-abc')
+    })
+
+    it('returns undefined when no traceId has been set', () => {
+        const carrier: Carrier = {}
+
+        expect(getCurrentTraceId(carrier)).toBeUndefined()
+    })
+
+    it('uses a custom carrier independently of globalThis', () => {
+        const carrier: Carrier = {}
+        setCurrentTraceId('carrier-trace', carrier)
+
+        expect(getCurrentTraceId(carrier)).toBe('carrier-trace')
+        expect(getCurrentTraceId()).toBeUndefined()
+    })
+
+    it('two separate carriers do not interfere with each other', () => {
+        const carrier1: Carrier = {}
+        const carrier2: Carrier = {}
+        setCurrentTraceId('trace-1', carrier1)
+        setCurrentTraceId('trace-2', carrier2)
+
+        expect(getCurrentTraceId(carrier1)).toBe('trace-1')
+        expect(getCurrentTraceId(carrier2)).toBe('trace-2')
+    })
+
+    it('setting undefined clears the stored traceId', () => {
+        const carrier: Carrier = {}
+        setCurrentTraceId('temp', carrier)
+        setCurrentTraceId(undefined, carrier)
+
+        expect(getCurrentTraceId(carrier)).toBeUndefined()
+    })
+
+    it('initializes the context object lazily on first set', () => {
+        const carrier: Carrier = {}
+
+        expect(carrier[TRACE_CONTEXT_KEY]).toBeUndefined()
+
+        setCurrentTraceId('lazy', carrier)
+
+        expect(carrier[TRACE_CONTEXT_KEY]).toBeDefined()
+    })
+
+    it('overwrites a previously stored traceId', () => {
+        const carrier: Carrier = {}
+        setCurrentTraceId('first', carrier)
+        setCurrentTraceId('second', carrier)
+
+        expect(getCurrentTraceId(carrier)).toBe('second')
+    })
+})

--- a/tests/runtime/tracing/traceStore.test.ts
+++ b/tests/runtime/tracing/traceStore.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { TraceStore } from '@observatory/runtime/tracing/traceStore'
+
+describe('TraceStore', () => {
+    let store: TraceStore
+
+    beforeEach(() => {
+        store = new TraceStore()
+    })
+
+    describe('createTrace', () => {
+        it('creates a trace with default values', () => {
+            const trace = store.createTrace()
+
+            expect(trace.id).toMatch(/^trace_/)
+            expect(trace.name).toBe('trace')
+            expect(trace.status).toBe('active')
+            expect(trace.spans).toEqual([])
+            expect(typeof trace.startTime).toBe('number')
+        })
+
+        it('accepts custom id, name, startTime, and metadata', () => {
+            const trace = store.createTrace({
+                id: 'my-trace',
+                name: 'route:/home',
+                startTime: 1000,
+                metadata: { kind: 'navigation' },
+            })
+
+            expect(trace.id).toBe('my-trace')
+            expect(trace.name).toBe('route:/home')
+            expect(trace.startTime).toBe(1000)
+            expect(trace.metadata).toEqual({ kind: 'navigation' })
+        })
+
+        it('stores the trace so it can be retrieved by getTrace', () => {
+            const trace = store.createTrace({ id: 'abc' })
+
+            expect(store.getTrace('abc')).toBe(trace)
+        })
+
+        it('does not set endTime or durationMs on a new trace', () => {
+            const trace = store.createTrace()
+
+            expect(trace.endTime).toBeUndefined()
+            expect(trace.durationMs).toBeUndefined()
+        })
+    })
+
+    describe('addSpan', () => {
+        it('appends a span to an existing trace', () => {
+            const trace = store.createTrace({ id: 'trace-1' })
+            const span = store.addSpan({ traceId: 'trace-1', name: 'my-span', type: 'custom' })
+
+            expect(trace.spans).toHaveLength(1)
+            expect(span.name).toBe('my-span')
+            expect(span.type).toBe('custom')
+            expect(span.status).toBe('active')
+            expect(span.traceId).toBe('trace-1')
+        })
+
+        it('auto-creates a trace for an unknown traceId via ensureTrace', () => {
+            const span = store.addSpan({ traceId: 'auto-created', name: 'late-span', type: 'fetch' })
+            const trace = store.getTrace('auto-created')
+
+            expect(trace).toBeDefined()
+            expect(trace?.spans).toHaveLength(1)
+            expect(span.traceId).toBe('auto-created')
+        })
+
+        it('sets durationMs and status ok when endTime is provided', () => {
+            store.createTrace({ id: 'trace-1', startTime: 0 })
+            const span = store.addSpan({
+                traceId: 'trace-1',
+                name: 'finished',
+                type: 'custom',
+                startTime: 100,
+                endTime: 200,
+            })
+
+            expect(span.durationMs).toBe(100)
+            expect(span.status).toBe('ok')
+            expect(span.endTime).toBe(200)
+        })
+
+        it('uses provided status over the endTime default', () => {
+            store.createTrace({ id: 'trace-1' })
+            const span = store.addSpan({
+                traceId: 'trace-1',
+                name: 'err',
+                type: 'fetch',
+                startTime: 0,
+                endTime: 50,
+                status: 'error',
+            })
+
+            expect(span.status).toBe('error')
+        })
+
+        it('preserves parentSpanId and metadata on the span', () => {
+            store.createTrace({ id: 'trace-1' })
+            const span = store.addSpan({
+                traceId: 'trace-1',
+                name: 'child',
+                type: 'component',
+                parentSpanId: 'parent-span',
+                metadata: { route: '/home' },
+            })
+
+            expect(span.parentSpanId).toBe('parent-span')
+            expect(span.metadata).toEqual({ route: '/home' })
+        })
+    })
+
+    describe('endTrace', () => {
+        it('sets endTime, durationMs, and status', () => {
+            store.createTrace({ id: 'trace-1', startTime: 0 })
+            const result = store.endTrace('trace-1', { endTime: 500, status: 'ok' })
+
+            expect(result?.endTime).toBe(500)
+            expect(result?.durationMs).toBe(500)
+            expect(result?.status).toBe('ok')
+        })
+
+        it('defaults status to ok when not specified', () => {
+            store.createTrace({ id: 'trace-1' })
+            store.endTrace('trace-1')
+
+            expect(store.getTrace('trace-1')?.status).toBe('ok')
+        })
+
+        it('merges metadata with existing trace metadata', () => {
+            store.createTrace({ id: 'trace-1', metadata: { initial: true } })
+            store.endTrace('trace-1', { metadata: { extra: 42 } })
+
+            expect(store.getTrace('trace-1')?.metadata).toMatchObject({ initial: true, extra: 42 })
+        })
+
+        it('sets metadata when the trace had none', () => {
+            store.createTrace({ id: 'trace-1' })
+            store.endTrace('trace-1', { metadata: { route: '/home' } })
+
+            expect(store.getTrace('trace-1')?.metadata).toEqual({ route: '/home' })
+        })
+
+        it('returns null for an unknown traceId', () => {
+            expect(store.endTrace('not-found')).toBeNull()
+        })
+
+        it('can mark a trace as cancelled', () => {
+            store.createTrace({ id: 'trace-1' })
+            store.endTrace('trace-1', { status: 'cancelled' })
+
+            expect(store.getTrace('trace-1')?.status).toBe('cancelled')
+        })
+    })
+
+    describe('endSpan', () => {
+        it('updates span endTime, durationMs, and status', () => {
+            store.createTrace({ id: 'trace-1', startTime: 0 })
+            const span = store.addSpan({ traceId: 'trace-1', name: 'sp', type: 'custom', startTime: 10 })
+            const result = store.endSpan(span.id, 'trace-1', { endTime: 60, status: 'ok' })
+
+            expect(result?.endTime).toBe(60)
+            expect(result?.durationMs).toBe(50)
+            expect(result?.status).toBe('ok')
+        })
+
+        it('defaults status to ok when not specified', () => {
+            store.createTrace({ id: 'trace-1' })
+            const span = store.addSpan({ traceId: 'trace-1', name: 'sp', type: 'custom' })
+            store.endSpan(span.id, 'trace-1')
+
+            expect(store.getTrace('trace-1')?.spans[0].status).toBe('ok')
+        })
+
+        it('merges metadata onto the span', () => {
+            store.createTrace({ id: 'trace-1' })
+            const span = store.addSpan({ traceId: 'trace-1', name: 'sp', type: 'custom', metadata: { base: 1 } })
+            store.endSpan(span.id, 'trace-1', { metadata: { added: 2 } })
+
+            expect(store.getTrace('trace-1')?.spans[0].metadata).toMatchObject({ base: 1, added: 2 })
+        })
+
+        it('returns null for an unknown traceId', () => {
+            expect(store.endSpan('span-x', 'no-trace')).toBeNull()
+        })
+
+        it('returns null for an unknown spanId', () => {
+            store.createTrace({ id: 'trace-1' })
+
+            expect(store.endSpan('no-span', 'trace-1')).toBeNull()
+        })
+    })
+
+    describe('getAllTraces / getTrace / clear', () => {
+        it('getAllTraces returns all stored traces', () => {
+            store.createTrace({ id: 'a' })
+            store.createTrace({ id: 'b' })
+
+            expect(store.getAllTraces()).toHaveLength(2)
+        })
+
+        it('getAllTraces returns a snapshot array (not the internal map)', () => {
+            store.createTrace({ id: 'a' })
+            const before = store.getAllTraces()
+            store.createTrace({ id: 'b' })
+
+            expect(before).toHaveLength(1)
+            expect(store.getAllTraces()).toHaveLength(2)
+        })
+
+        it('getTrace returns undefined for an unknown id', () => {
+            expect(store.getTrace('missing')).toBeUndefined()
+        })
+
+        it('clear removes all traces', () => {
+            store.createTrace({ id: 'a' })
+            store.createTrace({ id: 'b' })
+            store.clear()
+
+            expect(store.getAllTraces()).toHaveLength(0)
+        })
+    })
+
+    describe('computeDuration edge case', () => {
+        it('durationMs is 0 when endTime is before startTime', () => {
+            store.createTrace({ id: 'trace-1', startTime: 1000 })
+            const span = store.addSpan({
+                traceId: 'trace-1',
+                name: 'odd',
+                type: 'custom',
+                startTime: 500,
+                endTime: 100,
+            })
+
+            expect(span.durationMs).toBe(0)
+        })
+
+        it('endTrace durationMs is 0 when endTime is before startTime', () => {
+            store.createTrace({ id: 'trace-1', startTime: 1000 })
+            const result = store.endTrace('trace-1', { endTime: 500 })
+
+            expect(result?.durationMs).toBe(0)
+        })
+    })
+})

--- a/tests/runtime/tracing/tracing.test.ts
+++ b/tests/runtime/tracing/tracing.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { startSpan } from '@observatory/runtime/tracing/tracing'
+import { TraceStore } from '@observatory/runtime/tracing/traceStore'
+
+const TRACE_CONTEXT_KEY = '__observatory_trace_context__'
+interface Carrier {
+    [TRACE_CONTEXT_KEY]?: { currentTraceId?: string }
+}
+
+function makeContext() {
+    const store = new TraceStore()
+    const carrier: Carrier = {}
+
+    return { store, carrier }
+}
+
+describe('startSpan', () => {
+    it('creates a new trace when no active traceId exists', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan({ name: 'my-span', type: 'custom' }, { store, carrier })
+
+        expect(handle.trace).toBeDefined()
+        expect(handle.span.name).toBe('my-span')
+        expect(store.getAllTraces()).toHaveLength(1)
+    })
+
+    it('sets the currentTraceId on the carrier after the first call', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan({ name: 'span1', type: 'custom' }, { store, carrier })
+
+        expect(carrier[TRACE_CONTEXT_KEY]?.currentTraceId).toBe(handle.trace.id)
+    })
+
+    it('reuses the existing trace when carrier already has a currentTraceId', () => {
+        const { store, carrier } = makeContext()
+        const handle1 = startSpan({ name: 'span1', type: 'custom' }, { store, carrier })
+        const handle2 = startSpan({ name: 'span2', type: 'custom' }, { store, carrier })
+
+        expect(handle1.trace.id).toBe(handle2.trace.id)
+        expect(store.getAllTraces()).toHaveLength(1)
+        expect(store.getAllTraces()[0].spans).toHaveLength(2)
+    })
+
+    it('creates a separate trace when a fresh carrier is provided', () => {
+        const store = new TraceStore()
+        const carrier1: Carrier = {}
+        const carrier2: Carrier = {}
+        startSpan({ name: 'span1', type: 'custom' }, { store, carrier: carrier1 })
+        startSpan({ name: 'span2', type: 'custom' }, { store, carrier: carrier2 })
+
+        expect(store.getAllTraces()).toHaveLength(2)
+    })
+
+    it('end() transitions span status from active to ok', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan({ name: 'span1', type: 'custom' }, { store, carrier })
+
+        expect(handle.span.status).toBe('active')
+
+        handle.end({ status: 'ok' })
+
+        expect(handle.span.status).toBe('ok')
+        expect(handle.span.endTime).toBeDefined()
+        expect(handle.span.durationMs).toBeDefined()
+    })
+
+    it('end() is idempotent — second call does not overwrite the first', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan({ name: 'span1', type: 'custom' }, { store, carrier })
+        handle.end({ status: 'ok' })
+        const firstEndTime = handle.span.endTime
+
+        // Second call should be a no-op
+        handle.end({ status: 'error' })
+
+        expect(handle.span.endTime).toBe(firstEndTime)
+        expect(handle.span.status).toBe('ok')
+    })
+
+    it('end() merges metadata from startSpan and end call', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan(
+            { name: 'span1', type: 'custom', metadata: { initial: 1 } },
+            { store, carrier },
+        )
+        handle.end({ status: 'ok', metadata: { extra: 2 } })
+
+        expect(handle.span.metadata).toMatchObject({ initial: 1, extra: 2 })
+    })
+
+    it('end() with error status records the error', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan({ name: 'fetch-span', type: 'fetch' }, { store, carrier })
+        handle.end({ status: 'error', metadata: { statusCode: 500 } })
+
+        expect(handle.span.status).toBe('error')
+        expect(handle.span.metadata).toMatchObject({ statusCode: 500 })
+    })
+
+    it('uses traceName when creating a new trace', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan(
+            { name: 'nav-span', type: 'navigation' },
+            { store, carrier, traceName: 'route:/home' },
+        )
+
+        expect(handle.trace.name).toBe('route:/home')
+    })
+
+    it('uses traceMetadata when creating a new trace', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan(
+            { name: 'span', type: 'custom' },
+            { store, carrier, traceMetadata: { kind: 'route-navigation' } },
+        )
+
+        expect(handle.trace.metadata).toMatchObject({ kind: 'route-navigation' })
+    })
+
+    it('uses a custom startTime when provided', () => {
+        const { store, carrier } = makeContext()
+        const handle = startSpan({ name: 'timed', type: 'render', startTime: 100 }, { store, carrier })
+
+        expect(handle.span.startTime).toBe(100)
+    })
+
+    describe('with traceId provided directly on input', () => {
+        it('creates a new trace using the provided traceId if it does not exist', () => {
+            const { store, carrier } = makeContext()
+            const handle = startSpan({ name: 'span1', type: 'custom', traceId: 'explicit-id' }, { store, carrier })
+
+            expect(handle.trace.id).toBe('explicit-id')
+            expect(store.getTrace('explicit-id')).toBeDefined()
+        })
+
+        it('reuses an existing trace when a matching traceId exists in the store', () => {
+            const { store, carrier } = makeContext()
+            store.createTrace({ id: 'existing-trace' })
+            const handle = startSpan({ name: 'span1', type: 'custom', traceId: 'existing-trace' }, { store, carrier })
+
+            expect(handle.trace.id).toBe('existing-trace')
+            expect(store.getAllTraces()).toHaveLength(1)
+        })
+    })
+})


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the SSR trace store and runtime instrumentation modules, significantly improving test coverage and reliability for SSR tracing, async data instrumentation, and Vue component instrumentation.

**SSR Trace Store Tests**
- Adds tests for `createSsrRecord`, `addSsrFetchSpan`, and `drainSsrRecord`, covering record creation, span appending, metadata correctness, error handling, and record draining logic.

**Runtime Instrumentation Tests**

*Async Data Instrumentation:*
- Introduces tests for `useTracedAsyncData`, verifying correct span creation, metadata population, error handling, passthrough cases, and handler wrapping behavior.

*Component Instrumentation:*
- Adds tests for `setupComponentInstrumentation`, including mixin installation guards, component name resolution, filtering logic, and lifecycle hook span emission for render and update events.