### PR TITLE
Enhance reverse lookup with identity-based matching and key groups

### DIFF
--- a/client/src/views/ComposableTracker.vue
+++ b/client/src/views/ComposableTracker.vue
@@ -234,22 +234,67 @@ function toggleRefExpand(entryId: string, refKey: string) {
 }
 
 // ── Reverse lookup ────────────────────────────────────────────────────────
-// Clicking a ref key shows every mounted instance that exposes the same key.
+// Clicking a ref key prefers identity-based lookup for shared/global refs.
+// For non-shared keys, fallback to legacy key-name lookup.
 
-const lookupKey = ref<string | null>(null)
+interface LookupTarget {
+    key: string
+    composableName: string
+    identityGroup?: string
+}
+
+const lookupTarget = ref<LookupTarget | null>(null)
 
 const lookupResults = computed(() => {
-    if (!lookupKey.value) {
+    if (!lookupTarget.value) {
         return []
     }
 
-    const key = lookupKey.value
+    const target = lookupTarget.value
 
-    return entries.value.filter((e) => key in e.refs)
+    if (target.identityGroup) {
+        return entries.value.filter(
+            (entry) =>
+                entry.name === target.composableName &&
+                entry.sharedKeyGroups?.[target.key] === target.identityGroup &&
+                target.key in entry.refs,
+        )
+    }
+
+    return entries.value.filter((entry) => target.key in entry.refs)
 })
 
-function openLookup(key: string) {
-    lookupKey.value = lookupKey.value === key ? null : key
+const lookupTitle = computed(() => {
+    if (!lookupTarget.value) {
+        return ''
+    }
+
+    if (lookupTarget.value.identityGroup) {
+        return `${lookupTarget.value.key} (shared identity)`
+    }
+
+    return lookupTarget.value.key
+})
+
+function openLookup(entry: RuntimeComposableEntry, key: string) {
+    const identityGroup = entry.sharedKeyGroups?.[key]
+    const next: LookupTarget = {
+        key,
+        composableName: entry.name,
+        identityGroup,
+    }
+
+    if (
+        lookupTarget.value?.key === next.key &&
+        lookupTarget.value?.composableName === next.composableName &&
+        lookupTarget.value?.identityGroup === next.identityGroup
+    ) {
+        lookupTarget.value = null
+
+        return
+    }
+
+    lookupTarget.value = next
 }
 
 // ── Inline editing ────────────────────────────────────────────────────────
@@ -408,8 +453,12 @@ function applyEdit() {
                     <div v-for="[k, v] in Object.entries(entry.refs)" :key="k" class="composable-tracker__ref-row">
                         <span
                             class="composable-tracker__ref-key composable-tracker__ref-key--clickable mono text-sm"
-                            :title="`click to see all instances exposing '${k}'`"
-                            @click.stop="openLookup(k)"
+                            :title="
+                                entry.sharedKeyGroups?.[k]
+                                    ? `click to see instances sharing this exact '${k}' state`
+                                    : `click to see all instances exposing '${k}'`
+                            "
+                            @click.stop="openLookup(entry, k)"
                         >
                             {{ k }}
                         </span>
@@ -530,14 +579,14 @@ function applyEdit() {
 
         <!-- ── Reverse lookup panel ──────────────────────────────────────── -->
         <Transition name="slide">
-            <div v-if="lookupKey" class="composable-tracker__lookup-panel">
+            <div v-if="lookupTarget" class="composable-tracker__lookup-panel">
                 <div class="composable-tracker__lookup-header">
-                    <span class="mono text-sm">{{ lookupKey }}</span>
+                    <span class="mono text-sm">{{ lookupTitle }}</span>
                     <span class="muted text-sm">— {{ lookupResults.length }} instance{{ lookupResults.length !== 1 ? 's' : '' }}</span>
-                    <button class="composable-tracker__clear-btn composable-tracker__lookup-close" @click="lookupKey = null">✕</button>
+                    <button class="composable-tracker__clear-btn composable-tracker__lookup-close" @click="lookupTarget = null">✕</button>
                 </div>
                 <div v-if="!lookupResults.length" class="composable-tracker__lookup-empty muted text-sm">
-                    No mounted instances expose this key.
+                    No instances matched this lookup.
                 </div>
                 <div v-for="r in lookupResults" :key="r.id" class="composable-tracker__lookup-row">
                     <span class="mono text-sm">{{ r.name }}</span>

--- a/src/runtime/composables/composable-registry.ts
+++ b/src/runtime/composables/composable-registry.ts
@@ -22,6 +22,11 @@ export interface ComposableEntry {
      * instances of this composable — indicates module-level (global) state.
      */
     sharedKeys: string[]
+    /**
+     * Stable per-composable-name identity group id for each shared key.
+     * Keys are ref/reactive key names; values are group ids like `group-1`.
+     */
+    sharedKeyGroups?: Record<string, string>
     watcherCount: number
     intervalCount: number
     lifecycle: {
@@ -102,9 +107,10 @@ export function setupComposableRegistry() {
     // comparing object identity across instances of the same composable name.
     const rawRefs = new Map<string, Record<string, unknown>>()
 
-    // Cache for sharedKeys — keyed by composable name, maps entry id → shared key array.
+    // Cache for shared identity metadata — keyed by composable name.
+    // For each entry id we cache both the list of shared keys and a key->group map.
     // Recomputed only when entries are added or removed, never on every getAll() poll tick.
-    const sharedKeysCache = new Map<string, Map<string, string[]>>()
+    const sharedKeysCache = new Map<string, Map<string, { keys: string[]; groups: Record<string, string> }>>()
 
     // FIX #2: dirty flag + cached snapshot string.
     // Set to true whenever any mutation occurs. getSnapshot() rebuilds and
@@ -140,7 +146,7 @@ export function setupComposableRegistry() {
         invalidateSharedKeysForName(entryName)
     }
 
-    function getSharedKeys(id: string, name: string): string[] {
+    function getSharedKeys(id: string, name: string): { keys: string[]; groups: Record<string, string> } {
         // Return cached result if available
         let nameCache = sharedKeysCache.get(name)
 
@@ -149,8 +155,30 @@ export function setupComposableRegistry() {
         }
 
         // Recompute for all instances of this composable name at once
-        nameCache = new Map<string, string[]>()
+        nameCache = new Map<string, { keys: string[]; groups: Record<string, string> }>()
         sharedKeysCache.set(name, nameCache)
+
+        // Stable ids for shared object identities within this composable name.
+        const identityIds = new WeakMap<object, string>()
+        let nextIdentity = 1
+
+        const getIdentityGroup = (obj: unknown) => {
+            if (!obj || typeof obj !== 'object') {
+                return undefined
+            }
+
+            const target = obj as object
+            const existing = identityIds.get(target)
+
+            if (existing) {
+                return existing
+            }
+
+            const created = `group-${nextIdentity++}`
+            identityIds.set(target, created)
+
+            return created
+        }
 
         // Collect all entries with this name
         const peers = [...entries.entries()].filter(([, e]) => e.name === name)
@@ -158,11 +186,12 @@ export function setupComposableRegistry() {
         for (const [eid] of peers) {
             const ownRaw = rawRefs.get(eid)
             if (!ownRaw) {
-                nameCache.set(eid, [])
+                nameCache.set(eid, { keys: [], groups: {} })
                 continue
             }
 
             const shared = new Set<string>()
+            const groups: Record<string, string> = {}
 
             for (const [otherId] of peers) {
                 if (otherId === eid) {
@@ -178,14 +207,20 @@ export function setupComposableRegistry() {
                 for (const [key, obj] of Object.entries(ownRaw)) {
                     if (key in otherRaw && otherRaw[key] === obj) {
                         shared.add(key)
+
+                        const identity = getIdentityGroup(obj)
+
+                        if (identity) {
+                            groups[key] = identity
+                        }
                     }
                 }
             }
 
-            nameCache.set(eid, [...shared])
+            nameCache.set(eid, { keys: [...shared], groups })
         }
 
-        return nameCache.get(id) ?? []
+        return nameCache.get(id) ?? { keys: [], groups: {} }
     }
 
     // The current route path — updated by the plugin on every navigation so new
@@ -393,6 +428,8 @@ export function setupComposableRegistry() {
                   ])
               )
 
+        const shared = getSharedKeys(entry.id, entry.name)
+
         return {
             id: entry.id,
             name: entry.name,
@@ -403,7 +440,8 @@ export function setupComposableRegistry() {
             leakReason: entry.leakReason,
             refs: freshRefs,
             history: entryHistory.get(entry.id) ?? [],
-            sharedKeys: getSharedKeys(entry.id, entry.name),
+            sharedKeys: shared.keys,
+            sharedKeyGroups: shared.groups,
             watcherCount: entry.watcherCount,
             intervalCount: entry.intervalCount,
             lifecycle: entry.lifecycle,

--- a/src/types/snapshot.ts
+++ b/src/types/snapshot.ts
@@ -64,6 +64,7 @@ export interface ComposableEntry {
     refs: Record<string, { type: 'ref' | 'computed' | 'reactive'; value: unknown }>
     history: RefChangeEvent[]
     sharedKeys: string[]
+    sharedKeyGroups?: Record<string, string>
     watcherCount: number
     intervalCount: number
     lifecycle: {

--- a/tests/runtime/composable-registry.test.ts
+++ b/tests/runtime/composable-registry.test.ts
@@ -1086,6 +1086,12 @@ describe('setupComposableRegistry — sharedKeys / global vs local detection (pr
         // Both instances return the SAME ref object → 'count' should be flagged as shared
         entries.forEach((e) => expect(e.sharedKeys).toContain('count'))
 
+        // Shared keys should include a stable identity-group mapping for lookup.
+        const groupA = entries[0].sharedKeyGroups?.count
+        const groupB = entries[1].sharedKeyGroups?.count
+        expect(groupA).toBeDefined()
+        expect(groupA).toBe(groupB)
+
         appA.unmount()
         appB.unmount()
     })
@@ -1128,6 +1134,8 @@ describe('setupComposableRegistry — sharedKeys / global vs local detection (pr
         entries.forEach((e) => {
             expect(e.sharedKeys).toContain('global')
             expect(e.sharedKeys).not.toContain('local')
+            expect(e.sharedKeyGroups?.global).toBeDefined()
+            expect(e.sharedKeyGroups?.local).toBeUndefined()
         })
 
         appA.unmount()


### PR DESCRIPTION
This pull request enhances the composable tracker’s reverse lookup feature by introducing stable identity-group detection for shared refs, improving both the UI and the underlying registry logic. Now, when a user clicks a ref key, the tracker can distinguish between truly shared/global refs (by object identity) and non-shared keys, providing more precise lookup results and clearer UI feedback. The registry and snapshot types are updated to support this, and tests are added to verify correct identity grouping.

**Reverse Lookup and UI Improvements:**
- The reverse lookup now prefers identity-based matching for shared/global refs, falling back to legacy key-name lookup for non-shared keys. The UI shows a more descriptive title and count, and the lookup panel is updated to use the new logic and display. [[1]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4L237-R297) [[2]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4L411-R461) [[3]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4L533-R589)

**Composable Registry Enhancements:**
- The composable registry now computes and caches stable identity group IDs for each shared ref key, allowing the system to track which instances share the exact same object reference. This is exposed as a new `sharedKeyGroups` property on each entry. [[1]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6R25-R29) [[2]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6L105-R113) [[3]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6L143-R149) [[4]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6L152-R194) [[5]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6R210-R223) [[6]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6R431-R432) [[7]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6L406-R444)

**Type and Snapshot Updates:**
- The `ComposableEntry` type and related snapshot types are updated to include the optional `sharedKeyGroups` field, ensuring the new identity-group information is available throughout the codebase.

**Test Coverage:**
- New and updated tests ensure that shared refs are correctly assigned stable identity group IDs, and that these IDs match across instances sharing the same object. Tests also verify that `sharedKeyGroups` are only present for truly shared keys. [[1]](diffhunk://#diff-d4067d20f00d1dda9809aba3ca6074ef9e0a6c3a709b557b272664bd88814b4cR1089-R1094) [[2]](diffhunk://#diff-d4067d20f00d1dda9809aba3ca6074ef9e0a6c3a709b557b272664bd88814b4cR1137-R1138)