### PR TITLE
Implement deep search for composable entries and nested properties

### DIFF
--- a/client/src/composables/composable-search.ts
+++ b/client/src/composables/composable-search.ts
@@ -1,0 +1,130 @@
+import type { ComposableEntry } from '@observatory/types/snapshot'
+
+const MAX_SEARCH_DEPTH = 6
+const MAX_SEARCH_NODES = 1500
+
+interface SearchBudget {
+    nodes: number
+}
+
+function valueMatchesQuery(
+    value: unknown,
+    query: string,
+    seen: WeakSet<object>,
+    budget: SearchBudget,
+    depth = 0,
+): boolean {
+    if (budget.nodes >= MAX_SEARCH_NODES) {
+        return false
+    }
+
+    budget.nodes++
+
+    if (value === null || value === undefined) {
+        return false
+    }
+
+    const valueType = typeof value
+
+    if (valueType === 'string' || valueType === 'number' || valueType === 'boolean' || valueType === 'bigint') {
+        return String(value).toLowerCase().includes(query)
+    }
+
+    if (valueType !== 'object') {
+        return false
+    }
+
+    if (depth >= MAX_SEARCH_DEPTH) {
+        return false
+    }
+
+    const objectValue = value as object
+
+    if (seen.has(objectValue)) {
+        return false
+    }
+
+    seen.add(objectValue)
+
+    if (Array.isArray(value)) {
+        return value.some((item) => valueMatchesQuery(item, query, seen, budget, depth + 1))
+    }
+
+    if (value instanceof Map) {
+        for (const [mapKey, mapValue] of value.entries()) {
+            if (valueMatchesQuery(mapKey, query, seen, budget, depth + 1)) {
+                return true
+            }
+
+            if (valueMatchesQuery(mapValue, query, seen, budget, depth + 1)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    if (value instanceof Set) {
+        for (const setValue of value.values()) {
+            if (valueMatchesQuery(setValue, query, seen, budget, depth + 1)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    try {
+        const entries = Object.entries(value as Record<string, unknown>)
+
+        for (const [key, nestedValue] of entries) {
+            if (key.toLowerCase().includes(query)) {
+                return true
+            }
+
+            if (valueMatchesQuery(nestedValue, query, seen, budget, depth + 1)) {
+                return true
+            }
+        }
+    } catch {
+        // Ignore objects that throw on entry access and continue matching safely.
+        return false
+    }
+
+    return false
+}
+
+/**
+ * Returns true when a composable entry matches the search query.
+ * Search scope includes name, file, ref keys, and nested reactive key/value content.
+ */
+export function matchesComposableEntryQuery(entry: ComposableEntry, query: string): boolean {
+    const normalizedQuery = query.trim().toLowerCase()
+
+    if (!normalizedQuery) {
+        return true
+    }
+
+    if (entry.name.toLowerCase().includes(normalizedQuery)) {
+        return true
+    }
+
+    if (entry.componentFile.toLowerCase().includes(normalizedQuery)) {
+        return true
+    }
+
+    const seen = new WeakSet<object>()
+    const budget: SearchBudget = { nodes: 0 }
+
+    for (const [refKey, refInfo] of Object.entries(entry.refs)) {
+        if (refKey.toLowerCase().includes(normalizedQuery)) {
+            return true
+        }
+
+        if (valueMatchesQuery(refInfo.value, normalizedQuery, seen, budget)) {
+            return true
+        }
+    }
+
+    return false
+}

--- a/client/src/views/ComposableTracker.vue
+++ b/client/src/views/ComposableTracker.vue
@@ -6,6 +6,7 @@ import {
     editComposableValue,
     openInEditor as openInEditorFromStore,
 } from '@observatory-client/stores/observatory'
+import { matchesComposableEntryQuery } from '@observatory-client/composables/composable-search'
 import type { ComposableEntry as RuntimeComposableEntry } from '@observatory/types/snapshot'
 
 const { composables: rawEntries, connected, features, clearComposables } = useObservatoryData()
@@ -118,23 +119,8 @@ const filtered = computed(() => {
             return false
         }
 
-        const q = search.value.toLowerCase()
-
-        if (q) {
-            const matchesName = entry.name.toLowerCase().includes(q)
-            const matchesFile = entry.componentFile.toLowerCase().includes(q)
-            const matchesRef = Object.keys(entry.refs).some((k) => k.toLowerCase().includes(q))
-            const matchesVal = Object.values(entry.refs).some((v) => {
-                try {
-                    return String(JSON.stringify(v.value)).toLowerCase().includes(q)
-                } catch {
-                    return false
-                }
-            })
-
-            if (!matchesName && !matchesFile && !matchesRef && !matchesVal) {
-                return false
-            }
+        if (search.value.trim() && !matchesComposableEntryQuery(entry, search.value)) {
+            return false
         }
 
         return true
@@ -257,7 +243,7 @@ const lookupResults = computed(() => {
             (entry) =>
                 entry.name === target.composableName &&
                 entry.sharedKeyGroups?.[target.key] === target.identityGroup &&
-                target.key in entry.refs,
+                target.key in entry.refs
         )
     }
 

--- a/tests/runtime/composable-search.test.ts
+++ b/tests/runtime/composable-search.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest'
+import { matchesComposableEntryQuery } from '@observatory-client/composables/composable-search'
+import type { ComposableEntry } from '@observatory/types/snapshot'
+
+function makeEntry(overrides?: Partial<ComposableEntry>): ComposableEntry {
+    return {
+        id: 'entry-1',
+        name: 'usePreferences',
+        componentFile: '/app/components/PrefsPanel.vue',
+        componentUid: 1,
+        status: 'mounted',
+        leak: false,
+        refs: {},
+        history: [],
+        sharedKeys: [],
+        watcherCount: 0,
+        intervalCount: 0,
+        lifecycle: {
+            hasOnMounted: true,
+            hasOnUnmounted: true,
+            watchersCleaned: true,
+            intervalsCleaned: true,
+        },
+        file: '/app/composables/usePreferences.ts',
+        line: 1,
+        route: '/settings',
+        ...overrides,
+    }
+}
+
+describe('matchesComposableEntryQuery', () => {
+    it('matches nested reactive object keys', () => {
+        const entry = makeEntry({
+            refs: {
+                preferences: {
+                    type: 'reactive',
+                    value: {
+                        ui: {
+                            theme: {
+                                accentColor: 'teal',
+                            },
+                        },
+                    },
+                },
+            },
+        })
+
+        expect(matchesComposableEntryQuery(entry, 'accentcolor')).toBe(true)
+    })
+
+    it('matches nested reactive object values', () => {
+        const entry = makeEntry({
+            refs: {
+                cart: {
+                    type: 'reactive',
+                    value: {
+                        items: [
+                            { sku: 'SKU-1', title: 'Notebook' },
+                            { sku: 'SKU-2', title: 'Mechanical Keyboard' },
+                        ],
+                    },
+                },
+            },
+        })
+
+        expect(matchesComposableEntryQuery(entry, 'mechanical keyboard')).toBe(true)
+    })
+
+    it('matches nested array values', () => {
+        const entry = makeEntry({
+            refs: {
+                dashboard: {
+                    type: 'reactive',
+                    value: {
+                        widgets: [{ name: 'Revenue' }, { name: 'Latency' }],
+                    },
+                },
+            },
+        })
+
+        expect(matchesComposableEntryQuery(entry, 'latency')).toBe(true)
+    })
+
+    it('handles cyclic objects without throwing', () => {
+        const cyclic: Record<string, unknown> = { label: 'root' }
+        cyclic.self = cyclic
+
+        const entry = makeEntry({
+            refs: {
+                graph: {
+                    type: 'reactive',
+                    value: cyclic,
+                },
+            },
+        })
+
+        expect(() => matchesComposableEntryQuery(entry, 'root')).not.toThrow()
+        expect(matchesComposableEntryQuery(entry, 'root')).toBe(true)
+    })
+
+    it('returns false for non-matching query', () => {
+        const entry = makeEntry({
+            refs: {
+                state: {
+                    type: 'reactive',
+                    value: {
+                        filter: {
+                            status: 'active',
+                        },
+                    },
+                },
+            },
+        })
+
+        expect(matchesComposableEntryQuery(entry, 'does-not-exist')).toBe(false)
+    })
+})


### PR DESCRIPTION
This pull request refactors and improves the composable search functionality in the Composable Tracker feature. The main change is the introduction of a robust, recursive search utility that enables deep and accurate matching of search queries against composable entries, including nested reactive data. The update also adds comprehensive tests to ensure reliability and handles edge cases like cyclic data structures.

**Composable search improvements:**

* Added a new `matchesComposableEntryQuery` function in `composable-search.ts` that performs deep, recursive search matching for composable entries, supporting nested objects, arrays, Maps, Sets, and handling cyclic references safely. This replaces the previous shallow string-based matching logic.
* Updated `ComposableTracker.vue` to use the new `matchesComposableEntryQuery` function for filtering composable entries, simplifying the code and improving search accuracy. [[1]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4R9) [[2]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4L121-L138)

**Testing and reliability:**

* Introduced a new test suite in `composable-search.test.ts` to verify that the new search function correctly matches nested keys and values, supports arrays, and safely handles cyclic objects without errors.

**Code cleanup:**

* Minor formatting and consistency improvements in `ComposableTracker.vue` (e.g., trailing commas, line breaks).