### PR TITLE
Add cross-trace render comparison and aggregate render stats

### DIFF
--- a/client/src/composables/trace-render-aggregation.ts
+++ b/client/src/composables/trace-render-aggregation.ts
@@ -1,0 +1,254 @@
+import type { TraceEntry, TraceSpan } from '@observatory/types/snapshot'
+
+interface SpanMetadata {
+    uid?: string | number
+    componentName?: string
+    file?: string
+    lifecycle?: string
+}
+
+export interface TraceRenderStatsRow {
+    componentKey: string
+    componentName: string
+    file: string
+    uid: string | number
+    mountCount: number
+    rerenderCount: number
+    totalMs: number
+    avgMs: number
+}
+
+export interface CrossTraceRenderSummaryRow {
+    componentKey: string
+    componentName: string
+    file: string
+    tracesSeen: number
+    avgRerendersPerTrace: number
+    totalRerenders: number
+    totalMs: number
+    avgMsPerRender: number
+    selectedUid?: string | number
+    selectedRerenders?: number
+    baselineRerenders?: number
+    deltaVsBaseline?: number
+}
+
+function asMetadata(span: TraceSpan): SpanMetadata {
+    return ((span.metadata as Record<string, unknown> | undefined) ?? {}) as SpanMetadata
+}
+
+function normalizeMs(value?: number): number {
+    return Number.isFinite(value) ? (value as number) : 0
+}
+
+function getComponentIdentity(metadata: SpanMetadata, fallbackId: string): { key: string; name: string; file: string } {
+    const name = String(metadata.componentName ?? '').trim()
+    const file = String(metadata.file ?? '').trim()
+
+    if (name && file) {
+        return {
+            key: `${file}::${name}`,
+            name,
+            file,
+        }
+    }
+
+    if (name) {
+        return {
+            key: `name::${name}`,
+            name,
+            file,
+        }
+    }
+
+    return {
+        key: `unknown::${fallbackId}`,
+        name: fallbackId,
+        file,
+    }
+}
+
+/** Build per-trace render stats grouped by component UID. */
+export function buildRenderSummaryForTrace(trace?: TraceEntry): TraceRenderStatsRow[] {
+    if (!trace) {
+        return []
+    }
+
+    const byUid = new Map<string | number, { key: string; name: string; file: string; spans: TraceSpan[] }>()
+
+    for (const span of trace.spans) {
+        if (span.type !== 'render') {
+            continue
+        }
+
+        const metadata = asMetadata(span)
+        const uid = (metadata.uid as string | number | undefined) ?? span.id
+        const identity = getComponentIdentity(metadata, String(uid))
+
+        if (!byUid.has(uid)) {
+            byUid.set(uid, {
+                key: identity.key,
+                name: identity.name,
+                file: identity.file,
+                spans: [],
+            })
+        }
+
+        byUid.get(uid)!.spans.push(span)
+    }
+
+    const rows: TraceRenderStatsRow[] = []
+
+    for (const [uid, { key, name, file, spans }] of byUid) {
+        let mountCount = 0
+        let rerenderCount = 0
+        let totalMs = 0
+
+        for (const span of spans) {
+            const lifecycle = String(asMetadata(span).lifecycle ?? '')
+            const ms = normalizeMs(span.durationMs)
+
+            if (lifecycle === 'render:mount') {
+                mountCount++
+            } else {
+                rerenderCount++
+            }
+
+            totalMs += ms
+        }
+
+        const totalRenders = mountCount + rerenderCount
+        rows.push({
+            componentKey: key,
+            componentName: name || String(uid),
+            file,
+            uid,
+            mountCount,
+            rerenderCount,
+            totalMs,
+            avgMs: totalRenders > 0 ? totalMs / totalRenders : 0,
+        })
+    }
+
+    rows.sort((a, b) => b.rerenderCount - a.rerenderCount || b.totalMs - a.totalMs)
+
+    return rows
+}
+
+/** Build cross-trace render aggregation and comparison against a selected trace. */
+export function buildCrossTraceRenderSummary(traces: TraceEntry[], selectedTraceId?: string): CrossTraceRenderSummaryRow[] {
+    if (traces.length === 0) {
+        return []
+    }
+
+    const aggregate = new Map<
+        string,
+        {
+            componentName: string
+            file: string
+            tracesSeen: number
+            totalRerenders: number
+            totalRenders: number
+            totalMs: number
+            selectedUid?: string | number
+            selectedRerenders?: number
+        }
+    >()
+
+    for (const trace of traces) {
+        const rows = buildRenderSummaryForTrace(trace)
+
+        // Collapse multiple UIDs for the same component identity within one trace.
+        const perTrace = new Map<
+            string,
+            { name: string; file: string; rerenders: number; renders: number; ms: number; uid: string | number; peakUidRerenders: number }
+        >()
+
+        for (const row of rows) {
+            const existing = perTrace.get(row.componentKey)
+
+            if (!existing) {
+                perTrace.set(row.componentKey, {
+                    name: row.componentName,
+                    file: row.file,
+                    rerenders: row.rerenderCount,
+                    renders: row.mountCount + row.rerenderCount,
+                    ms: row.totalMs,
+                    uid: row.uid,
+                    peakUidRerenders: row.rerenderCount,
+                })
+                continue
+            }
+
+            existing.rerenders += row.rerenderCount
+            existing.renders += row.mountCount + row.rerenderCount
+            existing.ms += row.totalMs
+
+            // Keep the UID with higher re-render count for potential highlight mapping.
+            if (row.rerenderCount > existing.peakUidRerenders) {
+                existing.uid = row.uid
+                existing.peakUidRerenders = row.rerenderCount
+            }
+        }
+
+        for (const [componentKey, value] of perTrace) {
+            if (!aggregate.has(componentKey)) {
+                aggregate.set(componentKey, {
+                    componentName: value.name,
+                    file: value.file,
+                    tracesSeen: 0,
+                    totalRerenders: 0,
+                    totalRenders: 0,
+                    totalMs: 0,
+                })
+            }
+
+            const target = aggregate.get(componentKey)!
+            target.tracesSeen += 1
+            target.totalRerenders += value.rerenders
+            target.totalRenders += value.renders
+            target.totalMs += value.ms
+
+            if (selectedTraceId && trace.id === selectedTraceId) {
+                target.selectedUid = value.uid
+                target.selectedRerenders = value.rerenders
+            }
+        }
+    }
+
+    const rows: CrossTraceRenderSummaryRow[] = []
+
+    for (const [componentKey, value] of aggregate) {
+        const avgRerendersPerTrace = value.tracesSeen > 0 ? value.totalRerenders / value.tracesSeen : 0
+        const avgMsPerRender = value.totalRenders > 0 ? value.totalMs / value.totalRenders : 0
+
+        let baselineRerenders: number | undefined
+        let deltaVsBaseline: number | undefined
+
+        if (value.selectedRerenders !== undefined && value.tracesSeen > 1) {
+            const others = value.tracesSeen - 1
+            const othersTotal = value.totalRerenders - value.selectedRerenders
+            baselineRerenders = others > 0 ? othersTotal / others : 0
+            deltaVsBaseline = value.selectedRerenders - baselineRerenders
+        }
+
+        rows.push({
+            componentKey,
+            componentName: value.componentName,
+            file: value.file,
+            tracesSeen: value.tracesSeen,
+            avgRerendersPerTrace,
+            totalRerenders: value.totalRerenders,
+            totalMs: value.totalMs,
+            avgMsPerRender,
+            selectedUid: value.selectedUid,
+            selectedRerenders: value.selectedRerenders,
+            baselineRerenders,
+            deltaVsBaseline,
+        })
+    }
+
+    rows.sort((a, b) => b.avgRerendersPerTrace - a.avgRerendersPerTrace || b.totalMs - a.totalMs)
+
+    return rows
+}

--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -7,6 +7,11 @@ import SpanInspector from '@observatory-client/components/SpanInspector.vue'
 import TraceFilter from '@observatory-client/components/TraceFilter.vue'
 import { useTraceFilter } from '@observatory-client/composables/useTraceFilter'
 import { exportJson, importJson } from '@observatory-client/composables/useExportImport'
+import {
+    buildRenderSummaryForTrace,
+    buildCrossTraceRenderSummary,
+    type TraceRenderStatsRow,
+} from '@observatory-client/composables/trace-render-aggregation'
 import type { ObservatoryExportFile } from '@observatory-client/composables/useExportImport'
 import type { TraceEntry, TraceSpan } from '@observatory/types/snapshot'
 
@@ -20,7 +25,9 @@ const selectedSpan = ref<TraceSpan | undefined>(undefined)
 const viewMode = ref<'overview' | 'flamegraph' | 'waterfall'>('overview')
 const showFilters = ref(false)
 const renderSummaryOpen = ref(true)
+const crossTraceSummaryOpen = ref(true)
 const highlightedUid = ref<string | number | undefined>(undefined)
+const highlightedComponentKey = ref<string | undefined>(undefined)
 
 const {
     searchQuery,
@@ -60,82 +67,10 @@ const selectedTrace = computed(() => {
     return filteredTraces.value.find((t) => t.id === selectedTraceId.value)
 })
 
-/** Aggregate render spans in the selected trace by component UID. */
-interface RenderSummaryRow {
-    uid: string | number
-    componentName: string
-    file: string
-    mountCount: number
-    rerenderCount: number
-    totalMs: number
-    avgMs: number
-}
+const renderSummary = computed<TraceRenderStatsRow[]>(() => buildRenderSummaryForTrace(selectedTrace.value))
 
-const renderSummary = computed<RenderSummaryRow[]>(() => {
-    if (!selectedTrace.value) {
-        return []
-    }
-
-    const byUid = new Map<string | number, { spans: TraceSpan[]; name: string; file: string }>()
-
-    for (const span of selectedTrace.value.spans) {
-        if (span.type !== 'render') {
-            continue
-        }
-
-        const m = span.metadata as Record<string, unknown> | undefined
-
-        if (!m) {
-            continue
-        }
-
-        const uid = (m.uid as string | number | undefined) ?? span.id
-        const name = String(m.componentName ?? '')
-        const file = String(m.file ?? '')
-
-        if (!byUid.has(uid)) {
-            byUid.set(uid, { spans: [], name, file })
-        }
-
-        byUid.get(uid)!.spans.push(span)
-    }
-
-    const rows: RenderSummaryRow[] = []
-
-    for (const [uid, { spans, name, file }] of byUid) {
-        let mountCount = 0
-        let rerenderCount = 0
-        let totalMs = 0
-
-        for (const span of spans) {
-            const lifecycle = String((span.metadata as Record<string, unknown> | undefined)?.lifecycle ?? '')
-            const dur = span.durationMs ?? 0
-
-            if (lifecycle === 'render:mount') {
-                mountCount++
-            } else {
-                rerenderCount++
-            }
-
-            totalMs += dur
-        }
-
-        const totalRenders = mountCount + rerenderCount
-        rows.push({
-            uid,
-            componentName: name || String(uid),
-            file,
-            mountCount,
-            rerenderCount,
-            totalMs,
-            avgMs: totalRenders > 0 ? totalMs / totalRenders : 0,
-        })
-    }
-
-    // Sort by total re-renders descending, then by total time.
-    rows.sort((a, b) => b.rerenderCount - a.rerenderCount || b.totalMs - a.totalMs)
-
-    return rows
+const crossTraceRenderSummary = computed(() => {
+    return buildCrossTraceRenderSummary(filteredTraces.value, selectedTrace.value?.id)
 })
 
 function elapsedFromSpans(trace: TraceEntry): number | undefined {
@@ -218,11 +153,14 @@ function selectTrace(trace: TraceEntry) {
     selectedTraceId.value = trace.id
     selectedSpan.value = undefined
     highlightedUid.value = undefined
+    highlightedComponentKey.value = undefined
 }
 
 function handleClearFilters() {
     clearFilters()
     selectedSpan.value = undefined
+    highlightedUid.value = undefined
+    highlightedComponentKey.value = undefined
 }
 
 function handleSpanTypesUpdate(value: Set<string>) {
@@ -273,11 +211,51 @@ function handleBackToLive() {
     selectedTraceId.value = null
     selectedSpan.value = undefined
     highlightedUid.value = undefined
+    highlightedComponentKey.value = undefined
 }
 
 function handleRenderSummaryRowClick(uid: string | number) {
     // Toggle highlight: clicking the already-highlighted row deselects it.
     highlightedUid.value = highlightedUid.value === uid ? undefined : uid
+    highlightedComponentKey.value = undefined
+    selectedSpan.value = undefined
+}
+
+function formatDelta(value?: number): string {
+    if (value === undefined) {
+        return 'n/a'
+    }
+
+    const rounded = Math.round(value * 10) / 10
+
+    if (rounded > 0) {
+        return `+${rounded}`
+    }
+
+    return `${rounded}`
+}
+
+function handleCrossTraceRowClick(componentKey: string) {
+    const row = crossTraceRenderSummary.value.find((item) => item.componentKey === componentKey)
+
+    if (!row || row.selectedUid === undefined) {
+        highlightedUid.value = undefined
+        highlightedComponentKey.value = undefined
+        selectedSpan.value = undefined
+
+        return
+    }
+
+    if (highlightedComponentKey.value === componentKey) {
+        highlightedComponentKey.value = undefined
+        highlightedUid.value = undefined
+        selectedSpan.value = undefined
+
+        return
+    }
+
+    highlightedComponentKey.value = componentKey
+    highlightedUid.value = row.selectedUid
     selectedSpan.value = undefined
 }
 </script>
@@ -488,6 +466,64 @@ function handleRenderSummaryRowClick(uid: string | number) {
                                                     {{ row.rerenderCount }}
                                                 </td>
                                                 <td class="mono">{{ formatDuration(row.avgMs) }}</td>
+                                                <td class="mono">{{ formatDuration(row.totalMs) }}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </template>
+
+                            <!-- Cross-trace comparison panel -->
+                            <template v-if="crossTraceRenderSummary.length > 0">
+                                <div class="trace-viewer__render-summary-header" @click="crossTraceSummaryOpen = !crossTraceSummaryOpen">
+                                    <span class="trace-viewer__render-summary-toggle">{{ crossTraceSummaryOpen ? '▾' : '▸' }}</span>
+                                    <span class="trace-viewer__render-summary-title">Cross-Trace Render Comparison</span>
+                                    <span class="trace-viewer__render-summary-count muted"
+                                        >{{ crossTraceRenderSummary.length }} components · {{ filteredTraces.length }} traces</span
+                                    >
+                                    <span
+                                        v-if="highlightedComponentKey !== undefined"
+                                        class="trace-viewer__render-summary-clear"
+                                        @click.stop="
+                                            highlightedComponentKey = undefined
+                                            highlightedUid = undefined
+                                        "
+                                    >
+                                        ✕ clear
+                                    </span>
+                                </div>
+                                <div v-if="crossTraceSummaryOpen" class="trace-viewer__render-summary-table-wrap">
+                                    <table class="data-table trace-viewer__render-summary-table">
+                                        <thead>
+                                            <tr>
+                                                <th>Component</th>
+                                                <th title="How many traces include this component">Traces</th>
+                                                <th title="Average re-renders per trace">Avg Re-renders</th>
+                                                <th title="Re-renders in selected trace">Selected</th>
+                                                <th title="Selected trace vs other traces baseline">Delta</th>
+                                                <th title="Average render duration across all renders">Avg ms</th>
+                                                <th title="Sum of all render duration across filtered traces">Total ms</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr
+                                                v-for="row in crossTraceRenderSummary"
+                                                :key="row.componentKey"
+                                                :class="{
+                                                    'trace-viewer__render-summary-row--active': highlightedComponentKey === row.componentKey,
+                                                }"
+                                                class="trace-viewer__render-summary-row"
+                                                :title="row.file"
+                                                @click="handleCrossTraceRowClick(row.componentKey)"
+                                            >
+                                                <td class="mono">{{ row.componentName }}</td>
+                                                <td class="mono">{{ row.tracesSeen }}</td>
+                                                <td class="mono">{{ (Math.round(row.avgRerendersPerTrace * 10) / 10).toFixed(1) }}</td>
+                                                <td class="mono">{{ row.selectedRerenders ?? 'n/a' }}</td>
+                                                <td class="mono" :class="{ 'trace-viewer__render-hot': (row.deltaVsBaseline ?? 0) > 0 }">
+                                                    {{ formatDelta(row.deltaVsBaseline) }}
+                                                </td>
+                                                <td class="mono">{{ formatDuration(row.avgMsPerRender) }}</td>
                                                 <td class="mono">{{ formatDuration(row.totalMs) }}</td>
                                             </tr>
                                         </tbody>

--- a/tests/runtime/trace-render-aggregation.test.ts
+++ b/tests/runtime/trace-render-aggregation.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { buildRenderSummaryForTrace, buildCrossTraceRenderSummary } from '@observatory-client/composables/trace-render-aggregation'
+import type { TraceEntry, TraceSpan } from '@observatory/types/snapshot'
+
+function renderSpan(
+    id: string,
+    traceId: string,
+    uid: number,
+    componentName: string,
+    file: string,
+    lifecycle: 'render:mount' | 'render:update',
+    durationMs: number,
+): TraceSpan {
+    return {
+        id,
+        traceId,
+        name: 'component:render',
+        type: 'render',
+        startTime: 0,
+        durationMs,
+        status: 'ok',
+        metadata: {
+            uid,
+            componentName,
+            file,
+            lifecycle,
+        },
+    }
+}
+
+function makeTrace(id: string, spans: TraceSpan[]): TraceEntry {
+    return {
+        id,
+        name: `trace:${id}`,
+        startTime: 0,
+        status: 'ok',
+        spans,
+    }
+}
+
+describe('buildRenderSummaryForTrace', () => {
+    it('aggregates render spans by UID', () => {
+        const trace = makeTrace('t1', [
+            renderSpan('a1', 't1', 10, 'CartDrawer', '/components/CartDrawer.vue', 'render:mount', 4),
+            renderSpan('a2', 't1', 10, 'CartDrawer', '/components/CartDrawer.vue', 'render:update', 2),
+            renderSpan('b1', 't1', 11, 'PriceBadge', '/components/PriceBadge.vue', 'render:update', 1),
+        ])
+
+        const rows = buildRenderSummaryForTrace(trace)
+        const cart = rows.find((row) => row.uid === 10)
+        const badge = rows.find((row) => row.uid === 11)
+
+        expect(rows).toHaveLength(2)
+        expect(cart?.mountCount).toBe(1)
+        expect(cart?.rerenderCount).toBe(1)
+        expect(cart?.totalMs).toBe(6)
+        expect(badge?.mountCount).toBe(0)
+        expect(badge?.rerenderCount).toBe(1)
+    })
+})
+
+describe('buildCrossTraceRenderSummary', () => {
+    it('aggregates rerenders across traces by component identity', () => {
+        const t1 = makeTrace('t1', [renderSpan('a1', 't1', 1, 'CartDrawer', '/components/CartDrawer.vue', 'render:update', 3)])
+        const t2 = makeTrace('t2', [renderSpan('a2', 't2', 9, 'CartDrawer', '/components/CartDrawer.vue', 'render:update', 5)])
+
+        const rows = buildCrossTraceRenderSummary([t1, t2], 't2')
+        const cart = rows.find((row) => row.componentName === 'CartDrawer')
+
+        expect(cart).toBeDefined()
+        expect(cart?.tracesSeen).toBe(2)
+        expect(cart?.totalRerenders).toBe(2)
+        expect(cart?.avgRerendersPerTrace).toBe(1)
+        expect(cart?.selectedRerenders).toBe(1)
+        expect(cart?.baselineRerenders).toBe(1)
+        expect(cart?.deltaVsBaseline).toBe(0)
+    })
+
+    it('returns empty when there are no traces', () => {
+        expect(buildCrossTraceRenderSummary([], undefined)).toEqual([])
+    })
+
+    it('computes positive delta when selected trace rerenders more than baseline', () => {
+        const t1 = makeTrace('t1', [renderSpan('a1', 't1', 1, 'DashboardGrid', '/components/DashboardGrid.vue', 'render:update', 2)])
+        const t2 = makeTrace('t2', [
+            renderSpan('a2', 't2', 2, 'DashboardGrid', '/components/DashboardGrid.vue', 'render:update', 2),
+            renderSpan('a3', 't2', 2, 'DashboardGrid', '/components/DashboardGrid.vue', 'render:update', 2),
+            renderSpan('a4', 't2', 2, 'DashboardGrid', '/components/DashboardGrid.vue', 'render:update', 2),
+        ])
+
+        const rows = buildCrossTraceRenderSummary([t1, t2], 't2')
+        const grid = rows.find((row) => row.componentName === 'DashboardGrid')
+
+        expect(grid?.selectedRerenders).toBe(3)
+        expect(grid?.baselineRerenders).toBe(1)
+        expect(grid?.deltaVsBaseline).toBe(2)
+    })
+})


### PR DESCRIPTION
This pull request adds a new cross-trace render aggregation feature for component render analysis, refactors the per-trace render summary logic for better maintainability, and introduces comprehensive tests for the new aggregation logic. The main changes are the extraction of render aggregation logic into a dedicated composable, integration of cross-trace comparison into the UI, and improved state management for component highlighting.

### Cross-trace render aggregation and UI integration

* Added `buildRenderSummaryForTrace` and `buildCrossTraceRenderSummary` functions in the new `trace-render-aggregation.ts` composable to aggregate render stats per trace and across multiple traces, enabling comparison of component render behavior between traces.
* Integrated a new "Cross-Trace Render Comparison" panel in the `TraceViewer.vue` UI, allowing users to compare component re-render counts and durations across traces, with delta calculations versus the selected trace.

### Refactoring and state management

* Replaced the inline per-trace render summary logic in `TraceViewer.vue` with the new composable functions for improved maintainability and reusability.
* Improved state management for highlighted components and UIDs to support cross-trace selection and clear highlighting when traces or filters change. [[1]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R28-R30) [[2]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R156-R163) [[3]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R214-R258)

### Testing

* Added unit tests for both per-trace and cross-trace render aggregation logic in `trace-render-aggregation.test.ts`, ensuring correct aggregation and delta calculations.