### PR TITLE
Enhance SSR tracing with phase span tracking and update tests

### DIFF
--- a/src/runtime/nitro/fetch-capture.ts
+++ b/src/runtime/nitro/fetch-capture.ts
@@ -1,5 +1,5 @@
 import { getRequestURL, setResponseHeader, type H3Event } from 'h3'
-import { createSsrRecord, drainSsrRecord, type SsrTraceRecord } from './ssr-trace-store'
+import { addSsrPhaseSpan, createSsrRecord, drainSsrRecord, type SsrTraceRecord } from './ssr-trace-store'
 
 interface ObservatoryContext {
     __observatoryRequestId?: string
@@ -66,6 +66,7 @@ export default function fetchCapturePlugin(nitroApp: NitroAppLike) {
     // Also drain any record that was never picked up by render:html (e.g. API
     // routes or error responses that do not render HTML).
     nitroApp.hooks.hook('afterResponse', (...args: unknown[]) => {
+        const hookStart = performance.now()
         const event = args[0] as ObservatoryEvent
         const start = event.context.__ssrFetchStart
 
@@ -78,6 +79,19 @@ export default function fetchCapturePlugin(nitroApp: NitroAppLike) {
         const requestId = event.context.__observatoryRequestId
 
         if (requestId) {
+            if (start !== undefined) {
+                const hookEnd = performance.now()
+                addSsrPhaseSpan(requestId, {
+                    name: 'ssr:afterResponse',
+                    type: 'server',
+                    startMs: Math.max(hookStart - start, 0),
+                    endMs: Math.max(hookEnd - start, 0),
+                    metadata: {
+                        hook: 'afterResponse',
+                    },
+                })
+            }
+
             const durationMs = start !== undefined ? Math.max(performance.now() - start, 0) : 0
             drainSsrRecord(requestId, durationMs)
         }
@@ -87,6 +101,7 @@ export default function fetchCapturePlugin(nitroApp: NitroAppLike) {
     // Inject the completed SSR trace as inline JSON so the client plugin can
     // merge it into the client-side traceStore on startup.
     nitroApp.hooks.hook('render:html', (...args: unknown[]) => {
+        const hookStart = performance.now()
         const html = args[0] as NitroRenderHTMLContext
         const ctx = args[1] as { event: ObservatoryEvent }
         const event = ctx?.event
@@ -100,6 +115,20 @@ export default function fetchCapturePlugin(nitroApp: NitroAppLike) {
 
         if (!requestId) {
             return
+        }
+
+        if (start !== undefined) {
+            const hookEnd = performance.now()
+            addSsrPhaseSpan(requestId, {
+                name: 'ssr:render:html',
+                type: 'server',
+                startMs: Math.max(hookStart - start, 0),
+                endMs: Math.max(hookEnd - start, 0),
+                metadata: {
+                    hook: 'render:html',
+                    island: html.island === true,
+                },
+            })
         }
 
         const durationMs = start !== undefined ? Math.max(performance.now() - start, 0) : 0

--- a/src/runtime/nitro/ssr-trace-store.ts
+++ b/src/runtime/nitro/ssr-trace-store.ts
@@ -119,6 +119,52 @@ export function addSsrFetchSpan(
 }
 
 /**
+ * Append a generic SSR phase span (e.g. `render:html`, `afterResponse`) to
+ * an existing request record.
+ * @param {string} requestId - The request identifier returned by `createSsrRecord`.
+ * @param {object} opts - Span options.
+ * @param {string} opts.name - Human-readable span name.
+ * @param {string} [opts.type] - Span type. Defaults to `server`.
+ * @param {number} opts.startMs - Span start, in ms relative to request start.
+ * @param {number} opts.endMs - Span end, in ms relative to request start.
+ * @param {boolean} [opts.error] - Set to `true` to mark the span status as `error`.
+ * @param {Record<string, unknown>} [opts.metadata] - Additional metadata fields.
+ */
+export function addSsrPhaseSpan(
+    requestId: string,
+    opts: {
+        name: string
+        type?: string
+        startMs: number
+        endMs: number
+        error?: boolean
+        metadata?: Record<string, unknown>
+    },
+): void {
+    const record = pending.get(requestId)
+
+    if (!record) {
+        return
+    }
+
+    const durationMs = Math.max(opts.endMs - opts.startMs, 0)
+
+    record.spans.push({
+        id: newId('span'),
+        name: opts.name,
+        type: opts.type ?? 'server',
+        startTime: opts.startMs,
+        endTime: opts.endMs,
+        durationMs,
+        status: opts.error ? 'error' : 'ok',
+        metadata: {
+            origin: 'ssr',
+            ...(opts.metadata ?? {}),
+        },
+    })
+}
+
+/**
  * Finalize and remove the record for `requestId`. The pre-populated
  * navigation span is closed with `durationMs`. Returns `undefined` if the
  * requestId is unknown (e.g. non-page requests that never called

--- a/tests/nitro/fetch-capture.test.ts
+++ b/tests/nitro/fetch-capture.test.ts
@@ -99,9 +99,15 @@ describe('fetch-capture nitro plugin', () => {
         // The JSON must be parseable and contain a traceId and spans array.
         const match = html.bodyAppend[0].match(/>(.+)<\/script>/)
         const parsed = JSON.parse(match![1])
+
         expect(typeof parsed.traceId).toBe('string')
         expect(Array.isArray(parsed.spans)).toBe(true)
         expect(parsed.spans.length).toBeGreaterThan(0)
+
+        const names = parsed.spans.map((span: { name?: string }) => span.name)
+
+        expect(names).toContain('ssr:navigation')
+        expect(names).toContain('ssr:render:html')
     })
 
     it('does nothing in render:html when the event has no requestId', () => {

--- a/tests/nitro/ssr-trace-store.test.ts
+++ b/tests/nitro/ssr-trace-store.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import {
     createSsrRecord,
     addSsrFetchSpan,
+    addSsrPhaseSpan,
     drainSsrRecord,
 } from '@observatory/runtime/nitro/ssr-trace-store'
 
@@ -132,6 +133,40 @@ describe('addSsrFetchSpan', () => {
         const record = drainSsrRecord(id, 200)
 
         expect(record?.spans[1]?.durationMs).toBe(0)
+    })
+})
+
+describe('addSsrPhaseSpan', () => {
+    it('appends a server phase span to an existing record', () => {
+        const id = uniqueId()
+        createSsrRecord(id, '/page', 'GET')
+
+        addSsrPhaseSpan(id, {
+            name: 'ssr:render:html',
+            startMs: 12,
+            endMs: 30,
+            metadata: { hook: 'render:html' },
+        })
+
+        const record = drainSsrRecord(id, 100)
+        const phaseSpan = record?.spans.find((span) => span.name === 'ssr:render:html')
+
+        expect(phaseSpan).toBeDefined()
+        expect(phaseSpan?.type).toBe('server')
+        expect(phaseSpan?.status).toBe('ok')
+        expect(phaseSpan?.durationMs).toBe(18)
+        expect(phaseSpan?.metadata?.origin).toBe('ssr')
+        expect(phaseSpan?.metadata?.hook).toBe('render:html')
+    })
+
+    it('is a no-op when requestId does not exist', () => {
+        expect(() => {
+            addSsrPhaseSpan('missing', {
+                name: 'ssr:afterResponse',
+                startMs: 0,
+                endMs: 1,
+            })
+        }).not.toThrow()
     })
 })
 


### PR DESCRIPTION
This pull request enhances SSR (server-side rendering) tracing in the Nitro runtime by introducing a new generic phase span mechanism. It adds the ability to record detailed timing for SSR lifecycle phases (like `render:html` and `afterResponse`), improving traceability and diagnostics. The implementation is accompanied by new tests to ensure correctness.

### SSR Phase Span Instrumentation

* Added a new `addSsrPhaseSpan` function to `ssr-trace-store.ts`, allowing the capture of arbitrary SSR phase spans (e.g., `render:html`, `afterResponse`) with customizable metadata and timing.
* Updated `fetch-capture.ts` to instrument the `afterResponse` and `render:html` hooks, recording phase spans with precise start and end times relative to the request. [[1]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR69) [[2]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR82-R94) [[3]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR104) [[4]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR120-R133)
* Extended the import statements in both `fetch-capture.ts` and test files to include the new `addSsrPhaseSpan` function. [[1]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fL2-R2) [[2]](diffhunk://#diff-90f02315441d2e359e2a5a256788eaa97ce3cdbef9f6dafa8ab7c2cd9440c5caR5)

### Testing Improvements

* Added unit tests for `addSsrPhaseSpan` in `ssr-trace-store.test.ts`, verifying correct span creation and no-op behavior for missing request IDs.
* Enhanced `fetch-capture.test.ts` to assert that SSR phase spans such as `ssr:render:html` are present in the output trace.