### PR TITLE
Enhance observability with improved tracking and filtering features

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,27 +165,22 @@ wraps them with a tracking shim (`__trackComposable`) that:
 The panel provides:
 
 - **Navigation mode toggle** — switch between 'route' mode (clears entries on navigation) and 'session' mode (persists entries across pages). In session mode, a "clear session" button appears to manually reset the history
-- **Filtering** by status (all / mounted / unmounted / leaks only) and free-text search across composable name, source file, ref key names, and ref values
+- **Filtering** by status (all / mounted / unmounted / leaks only) and free-text search across composable name, source file, ref key names, ref values, and nested reactive object properties
 - **Recency-first ordering** — newest entries appear first, with layout-level composables pinned to the top (layout composables persist across page navigation)
 - **Inline ref chip preview** — up to three reactive values shown on the card without expanding, with distinct styling for `ref`, `computed`, and `reactive` types
 - **Collapsible ref values** — long objects and arrays automatically collapse with a chevron toggle to expand them inline in the detail view with full pretty-printed JSON
 - **Global state badges** — keys shared across instances are highlighted in amber with a `global` badge and an explanatory banner when expanded
 - **Change history** — a scrollable log of the last 50 value mutations with key, new value, and relative timestamp
 - **Lifecycle summary** — shows whether `onMounted`/`onUnmounted` were registered and whether watchers and intervals were properly cleaned up
-- **Reverse lookup** — clicking any ref key opens a panel listing every other composable instance that exposes a key with the same name, with its composable name, file, and route
+- **Reverse lookup** — clicking any ref key opens a panel listing related composable instances. For shared/global refs it matches by shared object identity; otherwise it falls back to key-name matching
 - **Inline value editing** — writable `ref` values have an `edit` button; clicking opens a JSON textarea that applies the new value directly to the live ref in the running app
 - **Jump to editor** — an `open ↗` button in the context section opens the composable's source file in the configured editor
-
-**Known gaps:**
-
-- Reverse lookup matches by key name only, not by object identity
-- Search does not look inside nested `reactive` object properties
 
 ### Render Heatmap
 
 [![Render Heatmap](https://github.com/victorlmneves/nuxt-devtools-observatory/blob/main/docs/screenshots/render-heatmap.png)](https://github.com/victorlmneves/nuxt-devtools-observatory/blob/main/docs/screenshots/render-heatmap.png)
 
-Uses Vue's built-in `renderTriggered` mixin hook and `app.config.performance = true`.
+Uses Vue lifecycle instrumentation with `app.config.performance = true`.
 Accurate duration is measured by bracketing each `beforeMount`/`mounted` and
 `beforeUpdate`/`updated` cycle with `performance.now()` timestamps.
 Component bounding boxes are captured via `$el.getBoundingClientRect()` for the DOM
@@ -197,8 +192,7 @@ last). Every mount and update cycle appends an event recording:
 - `kind` — `mount` or `update`
 - `t` — `performance.now()` timestamp
 - `durationMs` — measured render duration
-- `triggerKey` — the reactive dep that caused the update (when `renderTriggered` fired
-  before `updated`), formatted as `type: key`
+- `triggerKey` — optional reactive dep label for the update (when available)
 - `route` — the route path at the time of the render
 
 A `route` field on each entry records which route the component was first seen on.
@@ -249,14 +243,15 @@ after a route change.
 
 **Span types collected:**
 
-| Type         | Emitted by                        | What it measures                                     |
-| ------------ | --------------------------------- | ---------------------------------------------------- |
-| `navigation` | `router.afterEach` hook           | Route change from → to, duration                     |
-| `component`  | Vue mixin lifecycle hooks         | Exact `mounted` / `updated` hook cost                |
-| `render`     | `beforeMount` → `mounted` bracket | Real DOM-patching time per component mount/update    |
-| `fetch`      | `useFetch` / `useAsyncData` shim  | Network request start, server/client origin, latency |
-| `composable` | `__trackComposable` shim          | Setup phase of every tracked `useXxx()` call         |
-| `transition` | `<Transition>` wrapper            | Full enter/leave lifecycle phase                     |
+| Type         | Emitted by                        | What it measures                                       |
+| ------------ | --------------------------------- | ------------------------------------------------------ |
+| `navigation` | `router.afterEach` hook           | Route change from → to, duration                       |
+| `component`  | Vue mixin lifecycle hooks         | Exact `mounted` / `updated` hook cost                  |
+| `render`     | `beforeMount` → `mounted` bracket | Real DOM-patching time per component mount/update      |
+| `fetch`      | `useFetch` / `useAsyncData` shim  | Network request start, server/client origin, latency   |
+| `server`     | Nitro SSR lifecycle hooks         | Server-side phase timing (e.g. `render:html`)          |
+| `composable` | `__trackComposable` shim          | Setup phase of tracked `useXxx()` calls (client + SSR) |
+| `transition` | `<Transition>` wrapper            | Full enter/leave lifecycle phase                       |
 
 **Render span tracking:**
 Real render time is measured by storing `performance.now()` in a `WeakMap<ComponentPublicInstance, number>` inside `beforeMount` / `beforeUpdate`, then reading it back in the corresponding `mounted` / `updated` hooks. This produces a `type: 'render'` span whose duration is the actual DOM-patching cost, separately from the `component:mounted` hook span (which only measures the hook body itself).
@@ -277,6 +272,9 @@ The panel provides:
   (always exports the full unfiltered dataset); `↑ import` loads a previously exported
   file and freezes the view on the imported data; a `← live` button returns to the
   live stream; the trace count label shows `(imported)` while viewing imported data
+- **Cross-trace render comparison** — compares render behavior across filtered traces,
+  with per-component average re-renders per trace, selected-trace value, and delta
+  versus baseline
 
 **What it tells you:**
 
@@ -285,11 +283,6 @@ The panel provides:
 - Which `useFetch` calls are in the critical path and how long each took
 - Whether composable setup is adding meaningful latency
 - Which components are slow to mount and might benefit from `<Suspense>` or lazy loading
-
-**Known gaps:**
-
-- SSR spans are not yet captured — only client-side navigation traces are collected
-- Re-render counts are tracked by Render Heatmap; the Trace Viewer records individual render events but does not aggregate them
 
 ### Transition Tracker
 
@@ -336,15 +329,7 @@ const result = useMyComposable()
 
 ## Roadmap
 
-### Composable Tracker
-
-- [ ] Reverse lookup by object identity rather than key name only
-- [ ] Deep search inside nested `reactive` object properties
-
-### Trace Viewer
-
-- [ ] SSR span collection (server-side navigation and composable setup)
-- [ ] Cross-trace comparison view
+- [ ] Dedicated cross-trace comparison UI polish (sorting, stronger visual deltas, and quick filtering)
 
 ## Development
 
@@ -390,7 +375,7 @@ src/
     │   ├── fetch-registry.ts           ← Fetch tracking store + __devFetch shim
     │   ├── provide-inject-registry.ts  ← Injection tracking + __devProvide/__devInject
     │   ├── composable-registry.ts      ← Composable tracking + __trackComposable + leak detection
-    │   ├── render-registry.ts          ← Render performance data via PerformanceObserver
+    │   ├── render-registry.ts          ← Render registry (timeline, route attribution, bbox snapshots)
     │   └── transition-registry.ts      ← Transition lifecycle store
     ├── instrumentation/
     │   ├── route.ts                    ← router.afterEach hook — opens/closes traces per navigation
@@ -403,7 +388,7 @@ src/
     │   ├── tracing.ts                  ← Span open/close helpers
     │   └── context.ts                  ← Current-trace context (per async task)
     └── nitro/
-        └── fetch-capture.ts            ← SSR-side fetch timing
+      └── fetch-capture.ts            ← SSR request tracing bridge (fetch + server phases + context)
 
 client/
 ├── index.html
@@ -415,6 +400,8 @@ client/
     ├── style.css                       ← Design system
     ├── components/
     ├── composables/
+    │   ├── composable-search.ts        ← Deep nested composable search matching utilities
+    │   ├── trace-render-aggregation.ts ← Per-trace and cross-trace render aggregation helpers
     │   ├── useExportImport.ts          ← JSON export (download) and import (file picker) utilities
     │   ├── useResizablePane.ts         ← Resizable split-pane drag handle
     │   └── useTraceFilter.ts           ← Trace filter state and filtering logic

--- a/src/runtime/composables/composable-registry.ts
+++ b/src/runtime/composables/composable-registry.ts
@@ -1,4 +1,5 @@
 import { isRef, isReactive, isReadonly, unref, computed, watchEffect, getCurrentInstance, onUnmounted } from 'vue'
+import { addSsrPhaseSpan } from '../nitro/ssr-trace-store'
 
 export interface RefChangeEvent {
     t: number // performance.now() timestamp
@@ -55,6 +56,56 @@ interface TrackedInstance {
     scope?: { effects?: RuntimeEffect[] }
     bm?: unknown[]
     um?: unknown[]
+}
+
+interface SsrObservatoryEvent {
+    context?: {
+        __observatoryRequestId?: string
+        __ssrFetchStart?: number
+    }
+}
+
+interface GlobalSsrContextCarrier {
+    __observatorySsrContext__?: SsrObservatoryEvent['context']
+}
+
+function nowMs() {
+    return typeof performance !== 'undefined' && typeof performance.now === 'function' ? performance.now() : Date.now()
+}
+
+export function __recordSsrComposableSpan(
+    name: string,
+    meta: { file: string; line: number },
+    startTime: number,
+    endTime: number,
+    opts: { error?: unknown; event?: SsrObservatoryEvent } = {},
+) {
+    const eventContext = opts.event?.context ?? (globalThis as GlobalSsrContextCarrier).__observatorySsrContext__
+    const requestId = eventContext?.__observatoryRequestId
+    const requestStart = eventContext?.__ssrFetchStart
+
+    if (!requestId || typeof requestStart !== 'number') {
+        return
+    }
+
+    const metadata: Record<string, unknown> = {
+        file: meta.file,
+        line: meta.line,
+        phase: 'setup',
+    }
+
+    if (opts.error instanceof Error) {
+        metadata.errorMessage = opts.error.message
+    }
+
+    addSsrPhaseSpan(requestId, {
+        name: `composable:${name}`,
+        type: 'composable',
+        startMs: Math.max(startTime - requestStart, 0),
+        endMs: Math.max(endTime - requestStart, 0),
+        error: !!opts.error,
+        metadata,
+    })
 }
 
 /**
@@ -602,7 +653,17 @@ export function __trackComposable<T>(name: string, callFn: () => T, meta: { file
     }
 
     if (!import.meta.client) {
-        return callFn()
+        const startTime = nowMs()
+
+        try {
+            const result = callFn()
+            __recordSsrComposableSpan(name, meta, startTime, nowMs())
+
+            return result
+        } catch (error) {
+            __recordSsrComposableSpan(name, meta, startTime, nowMs(), { error })
+            throw error
+        }
     }
 
     const registry = (window as Window & { __observatory__?: { composable?: ReturnType<typeof setupComposableRegistry> } }).__observatory__

--- a/src/runtime/nitro/fetch-capture.ts
+++ b/src/runtime/nitro/fetch-capture.ts
@@ -6,6 +6,10 @@ interface ObservatoryContext {
     __ssrFetchStart?: number
 }
 
+interface GlobalSsrContextCarrier {
+    __observatorySsrContext__?: ObservatoryContext
+}
+
 // Nitro plugins receive plain H3Event objects; extend the context inline.
 type ObservatoryEvent = H3Event & { context: H3Event['context'] & ObservatoryContext }
 
@@ -59,6 +63,10 @@ export default function fetchCapturePlugin(nitroApp: NitroAppLike) {
         event.context.__observatoryRequestId = requestId
 
         createSsrRecord(requestId, route, method)
+        ;(globalThis as GlobalSsrContextCarrier).__observatorySsrContext__ = {
+            __observatoryRequestId: requestId,
+            __ssrFetchStart: start,
+        }
     })
 
     // ── afterResponse ──────────────────────────────────────────────────────
@@ -94,6 +102,12 @@ export default function fetchCapturePlugin(nitroApp: NitroAppLike) {
 
             const durationMs = start !== undefined ? Math.max(performance.now() - start, 0) : 0
             drainSsrRecord(requestId, durationMs)
+        }
+
+        const active = (globalThis as GlobalSsrContextCarrier).__observatorySsrContext__
+
+        if (active?.__observatoryRequestId === requestId) {
+            delete (globalThis as GlobalSsrContextCarrier).__observatorySsrContext__
         }
     })
 

--- a/tests/nitro/fetch-capture.test.ts
+++ b/tests/nitro/fetch-capture.test.ts
@@ -47,6 +47,9 @@ describe('fetch-capture nitro plugin', () => {
 
         expect(typeof event.context.__observatoryRequestId).toBe('string')
         expect((event.context.__observatoryRequestId as string).length).toBeGreaterThan(0)
+
+        const globalCtx = (globalThis as { __observatorySsrContext__?: { __observatoryRequestId?: string } }).__observatorySsrContext__
+        expect(globalCtx?.__observatoryRequestId).toBe(event.context.__observatoryRequestId)
     })
 
     it('sets the x-observatory-ssr-ms response header after a response', () => {
@@ -60,6 +63,8 @@ describe('fetch-capture nitro plugin', () => {
         const lastCall = setResponseHeader.mock.calls.at(-1)!
         expect(lastCall[1]).toBe('x-observatory-ssr-ms')
         expect(Number(lastCall[2])).toBeGreaterThanOrEqual(0)
+
+        expect((globalThis as { __observatorySsrContext__?: unknown }).__observatorySsrContext__).toBeUndefined()
     })
 
     it('the elapsed ms in the header is a non-negative integer', () => {

--- a/tests/runtime/composable-registry.test.ts
+++ b/tests/runtime/composable-registry.test.ts
@@ -1,7 +1,8 @@
 // @vitest-environment happy-dom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createApp, defineComponent, h, ref, reactive, watch, nextTick } from 'vue'
-import { setupComposableRegistry, __trackComposable } from '@observatory/runtime/composables/composable-registry'
+import { setupComposableRegistry, __trackComposable, __recordSsrComposableSpan } from '@observatory/runtime/composables/composable-registry'
+import { createSsrRecord, drainSsrRecord } from '@observatory/runtime/nitro/ssr-trace-store'
 
 type ObservatoryWindow = Window & { __observatory__?: { composable?: ReturnType<typeof setupComposableRegistry> } }
 
@@ -386,6 +387,63 @@ describe('__trackComposable', () => {
 
         expect(reg.getAll()[0].lifecycle.watchersCleaned).toBe(true)
         expect(reg.getAll()[0].leak).toBe(false)
+    })
+})
+
+describe('__recordSsrComposableSpan', () => {
+    it('records a composable setup span into the SSR trace record', () => {
+        const requestId = 'req-test-composable-1'
+        createSsrRecord(requestId, '/dashboard', 'GET')
+
+        __recordSsrComposableSpan('useDashboard', { file: 'composables/useDashboard.ts', line: 12 }, 110, 145, {
+            event: {
+                context: {
+                    __observatoryRequestId: requestId,
+                    __ssrFetchStart: 100,
+                },
+            },
+        })
+
+        const record = drainSsrRecord(requestId, 200)
+        const span = record?.spans.find((s) => s.name === 'composable:useDashboard')
+
+        expect(span).toBeDefined()
+        expect(span?.type).toBe('composable')
+        expect(span?.startTime).toBe(10)
+        expect(span?.endTime).toBe(45)
+        expect(span?.durationMs).toBe(35)
+        expect(span?.metadata?.phase).toBe('setup')
+        expect(span?.metadata?.file).toBe('composables/useDashboard.ts')
+        expect(span?.metadata?.line).toBe(12)
+    })
+
+    it('records an error status and message when setup throws', () => {
+        const requestId = 'req-test-composable-2'
+        createSsrRecord(requestId, '/dashboard', 'GET')
+
+        __recordSsrComposableSpan('useBroken', { file: 'composables/useBroken.ts', line: 7 }, 205, 210, {
+            error: new Error('boom'),
+            event: {
+                context: {
+                    __observatoryRequestId: requestId,
+                    __ssrFetchStart: 200,
+                },
+            },
+        })
+
+        const record = drainSsrRecord(requestId, 220)
+        const span = record?.spans.find((s) => s.name === 'composable:useBroken')
+
+        expect(span?.status).toBe('error')
+        expect(span?.metadata?.errorMessage).toBe('boom')
+    })
+
+    it('is a no-op when request context is missing', () => {
+        expect(() => {
+            __recordSsrComposableSpan('useNoop', { file: 'x.ts', line: 1 }, 0, 1, {
+                event: { context: {} },
+            })
+        }).not.toThrow()
     })
 })
 


### PR DESCRIPTION
This pull request introduces comprehensive support for tracking composable setup spans during server-side rendering (SSR), enabling detailed performance analysis for both client and SSR phases. It updates documentation to reflect new capabilities, implements SSR composable span tracking in the runtime, and adds corresponding tests to ensure correctness. Additionally, the README is improved to clarify features and remove outdated "known gaps".

**SSR Composable Span Tracking:**

* Adds the `__recordSsrComposableSpan` function in `composable-registry.ts` to record composable setup spans during SSR, capturing timing, file, line, and error info, and linking them to the correct SSR trace record (`src/runtime/composables/composable-registry.ts`) [[1]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6R61-R110) [[2]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6L605-R666).
* Modifies `__trackComposable` to invoke `__recordSsrComposableSpan` on the server, ensuring all tracked composables are measured during SSR (`src/runtime/composables/composable-registry.ts`).
* Updates the SSR fetch capture plugin to propagate SSR context globally, enabling composable span tracking to associate with the correct request, and ensures cleanup after response (`src/runtime/nitro/fetch-capture.ts`) [[1]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR9-R12) [[2]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR66-R69) [[3]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR106-R111).

**Testing Enhancements:**

* Adds unit tests for `__recordSsrComposableSpan`, verifying correct recording of composable spans, error handling, and no-op behavior when context is missing (`tests/runtime/composable-registry.test.ts`).
* Extends SSR fetch capture tests to verify global context propagation and cleanup (`tests/nitro/fetch-capture.test.ts`) [[1]](diffhunk://#diff-6b5229e92b273f50a4f2a8f5e8639ff0a9edd4a02c0fe342f174684b95ee580aR50-R52) [[2]](diffhunk://#diff-6b5229e92b273f50a4f2a8f5e8639ff0a9edd4a02c0fe342f174684b95ee580aR66-R67).

**Documentation and Developer Experience:**

* Updates the README to reflect new SSR composable tracking, cross-trace comparison, and deep nested composable search, and removes outdated "known gaps" sections. Also clarifies and expands module descriptions and roadmap items (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L168-R183) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L200-R195) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L253-R253) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R275-R277) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L289-L293) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L339-R332) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L393-R378) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L406-R391) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R403-R404).

**Summary of Most Important Changes:**

**SSR Composable Span Tracking**
- Introduced `__recordSsrComposableSpan` to record composable setup spans during SSR and integrated it into `__trackComposable`, enabling full composable performance tracing on the server. [[1]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6R61-R110) [[2]](diffhunk://#diff-fdd9616b2e446f1b44b9b68fa4509496741569e20be274af1685d7be9a6fe0e6L605-R666)
- Updated SSR fetch capture plugin to manage and propagate SSR context globally, ensuring composable spans are attributed to the correct SSR trace and cleaned up after response. [[1]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR9-R12) [[2]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR66-R69) [[3]](diffhunk://#diff-058d87eeaec0a0de1947243b933866995d28f4e8f2d0386961fb1b20bc3f467fR106-R111)

**Testing**
- Added unit tests for SSR composable span recording and error handling in `composable-registry.test.ts`.
- Enhanced SSR fetch capture tests to check global context propagation and cleanup. [[1]](diffhunk://#diff-6b5229e92b273f50a4f2a8f5e8639ff0a9edd4a02c0fe342f174684b95ee580aR50-R52) [[2]](diffhunk://#diff-6b5229e92b273f50a4f2a8f5e8639ff0a9edd4a02c0fe342f174684b95ee580aR66-R67)

**Documentation**
- Updated README to document SSR composable tracking, cross-trace comparison, deep nested search, and cleaned up outdated sections. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L168-R183) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L200-R195) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L253-R253) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R275-R277) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L289-L293) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L339-R332) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L393-R378) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L406-R391) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R403-R404)