### PR TITLE
Update npm setup in release workflow and streamline TraceViewer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
             - name: Setup npm for trusted publishing
               run: |
-                  npm install -g npm@latest
+                  corepack enable npm
                   npm --version
 
             - name: Install dependencies

--- a/client/src/components/TraceFilter.vue
+++ b/client/src/components/TraceFilter.vue
@@ -292,11 +292,9 @@ function getSpanTypeColor(type: string): string {
     background: var(--bg);
     outline: none;
     appearance: none;
-    appearance: none;
 }
 
 .trace-filter__duration-slider::-webkit-slider-thumb {
-    appearance: none;
     appearance: none;
     width: 12px;
     height: 12px;

--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -322,6 +322,11 @@ function sortIndicator(key: 'avgRerendersPerTrace' | 'deltaVsBaseline' | 'totalM
     return crossTraceSortDir.value === 'desc' ? ' ↓' : ' ↑'
 }
 
+function clearCrossTraceHighlight() {
+    highlightedComponentKey.value = undefined
+    highlightedUid.value = undefined
+}
+
 function handleCrossTraceRowClick(componentKey: string) {
     const row = crossTraceRows.value.find((item) => item.componentKey === componentKey)
 
@@ -575,10 +580,7 @@ function handleCrossTraceRowClick(componentKey: string) {
                                     <span
                                         v-if="highlightedComponentKey !== undefined"
                                         class="trace-viewer__render-summary-clear"
-                                        @click.stop="
-                                            highlightedComponentKey = undefined
-                                            highlightedUid = undefined
-                                        "
+                                        @click.stop="clearCrossTraceHighlight"
                                     >
                                         ✕ clear
                                     </span>


### PR DESCRIPTION
This pull request includes several improvements and small fixes to the release workflow and the trace viewer UI, mainly focused on code simplification and maintainability.

### Workflow improvements

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L37-R37): Replaced the global installation of the latest `npm` with `corepack enable npm` to better align with modern Node.js best practices.

### UI code simplification and maintainability

* [`client/src/views/TraceViewer.vue`](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R325-R329): Introduced a new `clearCrossTraceHighlight` function to centralize the logic for clearing highlighted trace rows, improving code reuse and clarity. The clear button now uses this function instead of duplicating logic inline. [[1]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R325-R329) [[2]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24L578-R583)

### Minor cleanup

* [`client/src/components/TraceFilter.vue`](diffhunk://#diff-38558a9a0b78f349a355dd5aba85b1978ccea1a38b3469cde2868283fa4720b3L295-L299): Removed a duplicate `appearance: none;` CSS property to clean up the style definition.