### PR TITLE
Implement virtualization support and add related tests

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -7,6 +7,7 @@ import ComposableTracker from './views/ComposableTracker.vue'
 import RenderHeatmap from './views/RenderHeatmap.vue'
 import TransitionTimeline from './views/TransitionTimeline.vue'
 import TraceViewer from './views/TraceViewer.vue'
+import { useVirtualizationFlags } from './composables/useVirtualizationFlags'
 
 const pathMap: Record<string, string> = {
     fetch: 'fetch',
@@ -21,6 +22,9 @@ const segment = window.location.pathname.split('/').filter(Boolean).pop() ?? ''
 const activeTab = ref(pathMap[segment] ?? 'fetch')
 
 const { features } = useObservatoryData()
+
+// Initializes rollout flags from query params before view rendering.
+useVirtualizationFlags()
 
 const tabs = computed(() => {
     const f = features.value || {}

--- a/client/src/composables/useVirtualizationConfig.ts
+++ b/client/src/composables/useVirtualizationConfig.ts
@@ -1,0 +1,40 @@
+import { computed, ref } from 'vue'
+
+const DEFAULT_ROW_HEIGHT = 34
+const DEFAULT_OVERSCAN = 10
+const MIN_OVERSCAN = 2
+const MAX_OVERSCAN = 40
+
+function clampOverscan(value: number): number {
+    if (!Number.isFinite(value)) {
+        return DEFAULT_OVERSCAN
+    }
+
+    return Math.max(MIN_OVERSCAN, Math.min(MAX_OVERSCAN, Math.round(value)))
+}
+
+export type VirtualizationPreset = {
+    rowHeight: number
+    overscan: number
+}
+
+export function useVirtualizationConfig(initial?: Partial<VirtualizationPreset>) {
+    const rowHeight = ref(initial?.rowHeight ?? DEFAULT_ROW_HEIGHT)
+    const overscan = ref(clampOverscan(initial?.overscan ?? DEFAULT_OVERSCAN))
+
+    const preset = computed<VirtualizationPreset>(() => ({
+        rowHeight: Math.max(20, rowHeight.value),
+        overscan: clampOverscan(overscan.value),
+    }))
+
+    return {
+        rowHeight,
+        overscan,
+        preset,
+    }
+}
+
+export const VIRTUALIZATION_DEFAULTS = {
+    rowHeight: DEFAULT_ROW_HEIGHT,
+    overscan: DEFAULT_OVERSCAN,
+} as const

--- a/client/src/composables/useVirtualizationFlags.ts
+++ b/client/src/composables/useVirtualizationFlags.ts
@@ -1,0 +1,129 @@
+import { computed, ref } from 'vue'
+
+type VirtualizationScreen = 'heatmap' | 'traces' | 'composables' | 'fetch' | 'transitions'
+
+type VirtualizationFlags = {
+    enabled: boolean
+    heatmap: boolean
+    traces: boolean
+    composables: boolean
+    fetch: boolean
+    transitions: boolean
+}
+
+const defaultFlags: VirtualizationFlags = {
+    enabled: false,
+    heatmap: false,
+    traces: false,
+    composables: false,
+    fetch: false,
+    transitions: false,
+}
+
+const flags = ref<VirtualizationFlags>({ ...defaultFlags })
+
+let initialized = false
+
+function parseBooleanParam(value: string | null): boolean | null {
+    if (value == null) {
+        return null
+    }
+
+    if (value === '1' || value === 'true' || value === 'on') {
+        return true
+    }
+
+    if (value === '0' || value === 'false' || value === 'off') {
+        return false
+    }
+
+    return null
+}
+
+function readFromStorage(): VirtualizationFlags {
+    return { ...defaultFlags }
+}
+
+function applyQueryOverrides(current: VirtualizationFlags): VirtualizationFlags {
+    if (typeof window === 'undefined') {
+        return current
+    }
+
+    const params = new URLSearchParams(window.location.search)
+    const globalParam = parseBooleanParam(params.get('virt'))
+
+    const next = { ...current }
+
+    if (globalParam != null) {
+        next.enabled = globalParam
+    }
+
+    const perScreen: Array<[VirtualizationScreen, string]> = [
+        ['heatmap', 'virtHeatmap'],
+        ['traces', 'virtTraces'],
+        ['composables', 'virtComposables'],
+        ['fetch', 'virtFetch'],
+        ['transitions', 'virtTransitions'],
+    ]
+
+    for (const [key, paramName] of perScreen) {
+        const override = parseBooleanParam(params.get(paramName))
+
+        if (override != null) {
+            next[key] = override
+        }
+    }
+
+    return next
+}
+
+function init() {
+    if (initialized) {
+        return
+    }
+
+    initialized = true
+    const stored = readFromStorage()
+    const merged = applyQueryOverrides(stored)
+    flags.value = merged
+}
+
+function setAllEnabled(value: boolean) {
+    const next = {
+        ...flags.value,
+        enabled: value,
+    }
+
+    flags.value = next
+}
+
+function setScreenEnabled(screen: VirtualizationScreen, value: boolean) {
+    const next = {
+        ...flags.value,
+        [screen]: value,
+    }
+
+    flags.value = next
+}
+
+export function useVirtualizationFlags() {
+    init()
+
+    const effective = computed(() => ({
+        enabled: flags.value.enabled,
+        heatmap: flags.value.enabled && flags.value.heatmap,
+        traces: flags.value.enabled && flags.value.traces,
+        composables: flags.value.enabled && flags.value.composables,
+        fetch: flags.value.enabled && flags.value.fetch,
+        transitions: flags.value.enabled && flags.value.transitions,
+    }))
+
+    return {
+        flags,
+        effective,
+        setAllEnabled,
+        setScreenEnabled,
+    }
+}
+
+export type { VirtualizationFlags, VirtualizationScreen }

--- a/client/src/views/ComposableTracker.vue
+++ b/client/src/views/ComposableTracker.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useVirtualizationConfig } from '@observatory-client/composables/useVirtualizationConfig'
+import { useVirtualizationFlags } from '@observatory-client/composables/useVirtualizationFlags'
 import {
     useObservatoryData,
     setComposableMode,
@@ -93,6 +96,10 @@ function openInEditor(file: string) {
 const filter = ref('all')
 const search = ref('')
 const expanded = ref<string | null>(null)
+const listScrollRef = ref<HTMLElement | null>(null)
+
+const { effective: virtualizationFlags } = useVirtualizationFlags()
+const { preset: virtualizationPreset } = useVirtualizationConfig({ rowHeight: 88, overscan: 8 })
 
 const entries = computed<RuntimeComposableEntry[]>(() => rawEntries.value)
 
@@ -140,6 +147,54 @@ const filtered = computed(() => {
 
     // Combine: layout entries first (already sorted by recency), then regular entries
     return [...layoutEntries, ...regularEntries]
+})
+
+const virtualizedCardsEnabled = computed(() => virtualizationFlags.value.composables && expanded.value === null)
+
+const listVirtualizerOptions = computed(() => ({
+    count: filtered.value.length,
+    getScrollElement: () => listScrollRef.value,
+    estimateSize: () => virtualizationPreset.value.rowHeight,
+    overscan: virtualizationPreset.value.overscan,
+}))
+
+const listVirtualizer = useVirtualizer(listVirtualizerOptions)
+
+const listVirtualItems = computed(() => {
+    if (!virtualizedCardsEnabled.value) {
+        return []
+    }
+
+    return listVirtualizer.value.getVirtualItems()
+})
+
+const topListPadding = computed(() => {
+    if (!virtualizedCardsEnabled.value || listVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    return listVirtualItems.value[0].start
+})
+
+const bottomListPadding = computed(() => {
+    if (!virtualizedCardsEnabled.value || listVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    const total = listVirtualizer.value.getTotalSize()
+    const last = listVirtualItems.value[listVirtualItems.value.length - 1]
+
+    return Math.max(0, total - last.end)
+})
+
+const visibleEntries = computed(() => {
+    if (!virtualizedCardsEnabled.value) {
+        return filtered.value
+    }
+
+    return listVirtualItems.value
+        .map((item) => filtered.value[item.index])
+        .filter((entry): entry is RuntimeComposableEntry => Boolean(entry))
 })
 
 function lifecycleRows(entry: RuntimeComposableEntry) {
@@ -371,9 +426,15 @@ function applyEdit() {
             </button>
         </div>
 
-        <div class="composable-tracker__list">
+        <div ref="listScrollRef" class="composable-tracker__list">
             <div
-                v-for="entry in filtered"
+                v-if="virtualizedCardsEnabled && topListPadding > 0"
+                class="composable-tracker__virtual-spacer"
+                :style="{ height: `${topListPadding}px` }"
+                aria-hidden="true"
+            />
+            <div
+                v-for="entry in visibleEntries"
                 :key="entry.id"
                 class="composable-tracker__card"
                 :class="{
@@ -558,6 +619,13 @@ function applyEdit() {
                 </div>
             </div>
 
+            <div
+                v-if="virtualizedCardsEnabled && bottomListPadding > 0"
+                class="composable-tracker__virtual-spacer"
+                :style="{ height: `${bottomListPadding}px` }"
+                aria-hidden="true"
+            />
+
             <div v-if="!filtered.length" class="composable-tracker__empty muted text-sm">
                 {{ connected ? 'No composables recorded yet.' : 'Waiting for connection to the Nuxt app…' }}
             </div>
@@ -642,6 +710,11 @@ function applyEdit() {
     flex-direction: column;
     gap: var(--tracker-space-2);
     min-height: 0;
+}
+
+.composable-tracker__virtual-spacer {
+    width: 100%;
+    flex-shrink: 0;
 }
 
 .composable-tracker__card {

--- a/client/src/views/FetchDashboard.vue
+++ b/client/src/views/FetchDashboard.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useVirtualizationConfig } from '@observatory-client/composables/useVirtualizationConfig'
+import { useVirtualizationFlags } from '@observatory-client/composables/useVirtualizationFlags'
 import { useResizablePane } from '@observatory-client/composables/useResizablePane'
 import { useObservatoryData } from '@observatory-client/stores/observatory'
 import type { FetchEntry } from '@observatory/types/snapshot'
@@ -13,6 +16,10 @@ const filter = ref<string>('all')
 const search = ref('')
 const selectedId = ref<string | null>(null)
 const waterfallOpen = ref(true)
+const tableScrollRef = ref<HTMLElement | null>(null)
+
+const { effective: virtualizationFlags } = useVirtualizationFlags()
+const { preset: virtualizationPreset } = useVirtualizationConfig({ rowHeight: 38, overscan: 12 })
 
 const entries = computed<FetchViewEntry[]>(() => {
     const sorted = [...fetch.value].sort((a, b) => a.startTime - b.startTime)
@@ -46,6 +53,52 @@ const filtered = computed(() => {
 
         return true
     })
+})
+
+const virtualizedRowsEnabled = computed(() => virtualizationFlags.value.fetch)
+
+const rowVirtualizerOptions = computed(() => ({
+    count: filtered.value.length,
+    getScrollElement: () => tableScrollRef.value,
+    estimateSize: () => virtualizationPreset.value.rowHeight,
+    overscan: virtualizationPreset.value.overscan,
+}))
+
+const rowVirtualizer = useVirtualizer(rowVirtualizerOptions)
+
+const virtualItems = computed(() => {
+    if (!virtualizedRowsEnabled.value) {
+        return []
+    }
+
+    return rowVirtualizer.value.getVirtualItems()
+})
+
+const topVirtualPadding = computed(() => {
+    if (!virtualizedRowsEnabled.value || virtualItems.value.length === 0) {
+        return 0
+    }
+
+    return virtualItems.value[0].start
+})
+
+const bottomVirtualPadding = computed(() => {
+    if (!virtualizedRowsEnabled.value || virtualItems.value.length === 0) {
+        return 0
+    }
+
+    const total = rowVirtualizer.value.getTotalSize()
+    const last = virtualItems.value[virtualItems.value.length - 1]
+
+    return Math.max(0, total - last.end)
+})
+
+const visibleRows = computed(() => {
+    if (!virtualizedRowsEnabled.value) {
+        return filtered.value
+    }
+
+    return virtualItems.value.map((item) => filtered.value[item.index]).filter((entry): entry is FetchViewEntry => Boolean(entry))
 })
 
 const metaRows = computed(() => {
@@ -173,7 +226,7 @@ function formatSize(bytes: number) {
         </div>
 
         <div class="fetch-dashboard__split tracker-split">
-            <div class="fetch-dashboard__table tracker-table-wrap">
+            <div ref="tableScrollRef" class="fetch-dashboard__table tracker-table-wrap">
                 <table class="data-table">
                     <thead>
                         <tr>
@@ -188,7 +241,14 @@ function formatSize(bytes: number) {
                     </thead>
                     <tbody>
                         <tr
-                            v-for="entry in filtered"
+                            v-if="virtualizedRowsEnabled && topVirtualPadding > 0"
+                            class="fetch-dashboard__virtual-spacer-row"
+                            aria-hidden="true"
+                        >
+                            <td colspan="7" :style="{ height: `${topVirtualPadding}px` }"></td>
+                        </tr>
+                        <tr
+                            v-for="entry in visibleRows"
                             :key="entry.id"
                             :class="{ selected: selected?.id === entry.id }"
                             @click="selectedId = entry.id"
@@ -220,6 +280,13 @@ function formatSize(bytes: number) {
                                     ></div>
                                 </div>
                             </td>
+                        </tr>
+                        <tr
+                            v-if="virtualizedRowsEnabled && bottomVirtualPadding > 0"
+                            class="fetch-dashboard__virtual-spacer-row"
+                            aria-hidden="true"
+                        >
+                            <td colspan="7" :style="{ height: `${bottomVirtualPadding}px` }"></td>
                         </tr>
                         <tr v-if="!filtered.length">
                             <td colspan="7" class="tracker-empty-cell">
@@ -295,6 +362,12 @@ function formatSize(bytes: number) {
 
 .fetch-dashboard__bar-column {
     min-width: 80px;
+}
+
+.fetch-dashboard__virtual-spacer-row td {
+    padding: 0;
+    border-bottom: 0;
+    background: transparent;
 }
 
 .fetch-dashboard__url {

--- a/client/src/views/RenderHeatmap.vue
+++ b/client/src/views/RenderHeatmap.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { computed, defineComponent, h, ref, watch, type VNode } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useVirtualizationConfig } from '@observatory-client/composables/useVirtualizationConfig'
+import { useVirtualizationFlags } from '@observatory-client/composables/useVirtualizationFlags'
 import { useResizablePane } from '@observatory-client/composables/useResizablePane'
 import { useObservatoryData, openInEditor as openInEditorFromStore } from '@observatory-client/stores/observatory'
 import { exportJson, importJson } from '@observatory-client/composables/useExportImport'
@@ -24,6 +27,29 @@ interface ComponentNode {
     isPersistent: boolean
     isHydrationMount: boolean
     route: string
+}
+
+function nodeBadges(node: ComponentNode): string[] {
+    const badges: string[] = []
+    const normalizedElement = node.element?.toLowerCase()
+
+    if (node.element && node.element !== node.label && !['div', 'span', 'p'].includes(normalizedElement ?? '')) {
+        badges.push(node.element)
+    }
+
+    if (node.file !== 'unknown') {
+        const fileBadge =
+            node.file
+                .split('/')
+                .pop()
+                ?.replace(/\.vue$/i, '') ?? node.file
+
+        if (fileBadge !== node.label && !badges.includes(fileBadge)) {
+            badges.push(fileBadge)
+        }
+    }
+
+    return badges
 }
 
 const TreeNode = defineComponent({
@@ -58,24 +84,7 @@ const TreeNode = defineComponent({
             const canExpand = node.children.length > 0
             const metric = props.mode === 'count' ? `${node.rerenders + node.mountCount}` : `${node.avgMs.toFixed(1)}ms`
             const metricLabel = props.mode === 'count' ? 'renders' : 'avg'
-            const badges = []
-            const normalizedElement = node.element?.toLowerCase()
-
-            if (node.element && node.element !== node.label && !['div', 'span', 'p'].includes(normalizedElement ?? '')) {
-                badges.push(node.element)
-            }
-
-            if (node.file !== 'unknown') {
-                const fileBadge =
-                    node.file
-                        .split('/')
-                        .pop()
-                        ?.replace(/\.vue$/i, '') ?? node.file
-
-                if (fileBadge !== node.label && !badges.includes(fileBadge)) {
-                    badges.push(fileBadge)
-                }
-            }
+            const badges = nodeBadges(node)
 
             return h('div', { class: 'tree-node' }, [
                 h(
@@ -206,6 +215,10 @@ const activeRootId = ref<string | null>(null)
 const expandedIds = ref<Set<string>>(new Set())
 const frozenSnapshot = ref<RenderEntry[]>([])
 const expansionReady = ref(false)
+const treeFrameRef = ref<HTMLElement | null>(null)
+
+const { effective: virtualizationFlags } = useVirtualizationFlags()
+const { preset: virtualizationPreset } = useVirtualizationConfig({ rowHeight: 34, overscan: 14 })
 
 function displayLabel(entry: RenderEntry) {
     if (entry.name && entry.name !== 'unknown' && !/^Component#\d+$/.test(entry.name)) {
@@ -503,6 +516,78 @@ const visibleTreeRoots = computed(() => {
     }
 
     return [visibleActiveRoot.value]
+})
+
+const virtualizedTreeEnabled = computed(() => virtualizationFlags.value.heatmap)
+
+function flattenVisibleTree(root: ComponentNode | null, expanded: Set<string>) {
+    if (!root) {
+        return [] as ComponentNode[]
+    }
+
+    const rows: ComponentNode[] = []
+
+    function walk(node: ComponentNode) {
+        rows.push(node)
+
+        if (!expanded.has(node.id)) {
+            return
+        }
+
+        node.children.forEach(walk)
+    }
+
+    walk(root)
+
+    return rows
+}
+
+const expandedVisibleNodes = computed(() => flattenVisibleTree(visibleActiveRoot.value, expandedIds.value))
+
+const treeVirtualizerOptions = computed(() => ({
+    count: expandedVisibleNodes.value.length,
+    getScrollElement: () => treeFrameRef.value,
+    estimateSize: () => virtualizationPreset.value.rowHeight,
+    overscan: virtualizationPreset.value.overscan,
+}))
+
+const treeVirtualizer = useVirtualizer(treeVirtualizerOptions)
+
+const treeVirtualItems = computed(() => {
+    if (!virtualizedTreeEnabled.value) {
+        return []
+    }
+
+    return treeVirtualizer.value.getVirtualItems()
+})
+
+const topTreePadding = computed(() => {
+    if (!virtualizedTreeEnabled.value || treeVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    return treeVirtualItems.value[0].start
+})
+
+const bottomTreePadding = computed(() => {
+    if (!virtualizedTreeEnabled.value || treeVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    const total = treeVirtualizer.value.getTotalSize()
+    const last = treeVirtualItems.value[treeVirtualItems.value.length - 1]
+
+    return Math.max(0, total - last.end)
+})
+
+const visibleTreeRows = computed(() => {
+    if (!virtualizedTreeEnabled.value) {
+        return expandedVisibleNodes.value
+    }
+
+    return treeVirtualItems.value
+        .map((item) => expandedVisibleNodes.value[item.index])
+        .filter((node): node is ComponentNode => Boolean(node))
 })
 
 const appEntries = computed(() =>
@@ -829,21 +914,93 @@ function formatTimestamp(t: number): string {
                     />
                 </div>
 
-                <div class="render-heatmap__tree-frame">
+                <div ref="treeFrameRef" class="render-heatmap__tree-frame">
                     <div class="render-heatmap__tree-canvas tree-canvas">
-                        <TreeNode
-                            v-for="root in visibleTreeRoots"
-                            :key="root.id"
-                            :node="root"
-                            :mode="activeMode"
-                            :threshold="activeThreshold"
-                            :selected="activeSelected?.id"
-                            :expanded-ids="expandedIds"
-                            @select="selectNode"
-                            @toggle="toggleNode"
-                        />
+                        <template v-if="virtualizedTreeEnabled">
+                            <div
+                                v-if="topTreePadding > 0"
+                                class="render-heatmap__tree-spacer"
+                                :style="{ height: `${topTreePadding}px` }"
+                                aria-hidden="true"
+                            />
+                            <div
+                                v-for="treeNode in visibleTreeRows"
+                                :key="treeNode.id"
+                                class="tree-row"
+                                :class="{ selected: activeSelected?.id === treeNode.id, hot: isHot(treeNode) }"
+                                :style="{ '--tree-depth': String(treeNode.depth) }"
+                                @click="selectNode(treeNode)"
+                            >
+                                <span class="tree-rail" aria-hidden="true" />
+                                <button
+                                    class="tree-toggle"
+                                    :class="{ empty: !treeNode.children.length }"
+                                    :disabled="!treeNode.children.length"
+                                    @click.stop="treeNode.children.length ? toggleNode(treeNode.id) : undefined"
+                                >
+                                    {{ treeNode.children.length ? (expandedIds.has(treeNode.id) ? '⌄' : '›') : '' }}
+                                </button>
+                                <div class="tree-copy">
+                                    <span class="tree-name mono" :title="treeNode.label">{{ treeNode.label }}</span>
+                                    <div v-if="nodeBadges(treeNode).length" class="tree-badges">
+                                        <span class="tree-badge mono" :title="nodeBadges(treeNode)[0]">{{ nodeBadges(treeNode)[0] }}</span>
+                                    </div>
+                                </div>
+                                <div class="tree-metrics mono">
+                                    <span
+                                        v-if="treeNode.isPersistent"
+                                        class="tree-persistent-pill"
+                                        title="Layout / persistent component — survives navigation"
+                                    >
+                                        persistent
+                                    </span>
+                                    <span
+                                        v-if="treeNode.isHydrationMount"
+                                        class="tree-hydration-pill"
+                                        title="First mount was SSR hydration — not a user-triggered render"
+                                    >
+                                        hydrated
+                                    </span>
+                                    <span class="tree-metric-pill">
+                                        {{
+                                            activeMode === 'count'
+                                                ? treeNode.rerenders + treeNode.mountCount
+                                                : `${treeNode.avgMs.toFixed(1)}ms`
+                                        }}
+                                        {{ activeMode === 'count' ? 'renders' : 'avg' }}
+                                    </span>
+                                    <button
+                                        v-if="treeNode.file && treeNode.file !== 'unknown'"
+                                        class="tree-jump-btn"
+                                        :title="`Open ${treeNode.file} in editor`"
+                                        @click.stop="openInEditor(treeNode.file)"
+                                    >
+                                        ↗
+                                    </button>
+                                </div>
+                            </div>
+                            <div
+                                v-if="bottomTreePadding > 0"
+                                class="render-heatmap__tree-spacer"
+                                :style="{ height: `${bottomTreePadding}px` }"
+                                aria-hidden="true"
+                            />
+                        </template>
+                        <template v-else>
+                            <TreeNode
+                                v-for="root in visibleTreeRoots"
+                                :key="root.id"
+                                :node="root"
+                                :mode="activeMode"
+                                :threshold="activeThreshold"
+                                :selected="activeSelected?.id"
+                                :expanded-ids="expandedIds"
+                                @select="selectNode"
+                                @toggle="toggleNode"
+                            />
+                        </template>
                     </div>
-                    <div v-if="!visibleTreeRoots.length" class="render-heatmap__detail-empty">
+                    <div v-if="!expandedVisibleNodes.length" class="render-heatmap__detail-empty">
                         {{ connected ? 'No render activity recorded yet.' : 'Waiting for connection to the Nuxt app…' }}
                     </div>
                 </div>
@@ -1132,6 +1289,10 @@ function formatTimestamp(t: number): string {
     display: inline-block;
     min-width: 100%;
     width: max-content;
+}
+
+.render-heatmap__tree-spacer {
+    width: 100%;
 }
 
 :deep(.tree-node) {

--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useVirtualizationConfig } from '@observatory-client/composables/useVirtualizationConfig'
+import { useVirtualizationFlags } from '@observatory-client/composables/useVirtualizationFlags'
 import { useObservatoryData } from '@observatory-client/stores/observatory'
 import Flamegraph from '@observatory-client/components/Flamegraph.vue'
 import WaterfallView from '@observatory-client/components/WaterfallView.vue'
@@ -10,6 +13,7 @@ import { exportJson, importJson } from '@observatory-client/composables/useExpor
 import {
     buildRenderSummaryForTrace,
     buildCrossTraceRenderSummary,
+    type CrossTraceRenderSummaryRow,
     type TraceRenderStatsRow,
 } from '@observatory-client/composables/trace-render-aggregation'
 import type { ObservatoryExportFile } from '@observatory-client/composables/useExportImport'
@@ -33,6 +37,11 @@ const crossTraceOnlyComparable = ref(false)
 const crossTraceSearch = ref('')
 const highlightedUid = ref<string | number | undefined>(undefined)
 const highlightedComponentKey = ref<string | undefined>(undefined)
+const traceListScrollRef = ref<HTMLElement | null>(null)
+const crossTraceScrollRef = ref<HTMLElement | null>(null)
+
+const { effective: virtualizationFlags } = useVirtualizationFlags()
+const { preset: virtualizationPreset } = useVirtualizationConfig({ rowHeight: 34, overscan: 12 })
 
 const {
     searchQuery,
@@ -124,6 +133,100 @@ const crossTraceRows = computed(() => {
 })
 
 const crossTraceRegressionsCount = computed(() => crossTraceRenderSummary.value.filter((row) => (row.deltaVsBaseline ?? 0) > 0).length)
+
+const virtualizedTraceRowsEnabled = computed(() => virtualizationFlags.value.traces)
+
+const traceListVirtualizerOptions = computed(() => ({
+    count: filteredTraces.value.length,
+    getScrollElement: () => traceListScrollRef.value,
+    estimateSize: () => virtualizationPreset.value.rowHeight,
+    overscan: virtualizationPreset.value.overscan,
+}))
+
+const traceListVirtualizer = useVirtualizer(traceListVirtualizerOptions)
+
+const traceListVirtualItems = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value) {
+        return []
+    }
+
+    return traceListVirtualizer.value.getVirtualItems()
+})
+
+const traceListTopPadding = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value || traceListVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    return traceListVirtualItems.value[0].start
+})
+
+const traceListBottomPadding = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value || traceListVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    const total = traceListVirtualizer.value.getTotalSize()
+    const last = traceListVirtualItems.value[traceListVirtualItems.value.length - 1]
+
+    return Math.max(0, total - last.end)
+})
+
+const visibleTraceRows = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value) {
+        return filteredTraces.value
+    }
+
+    return traceListVirtualItems.value
+        .map((item) => filteredTraces.value[item.index])
+        .filter((trace): trace is TraceEntry => Boolean(trace))
+})
+
+const crossTraceVirtualizerOptions = computed(() => ({
+    count: crossTraceRows.value.length,
+    getScrollElement: () => crossTraceScrollRef.value,
+    estimateSize: () => virtualizationPreset.value.rowHeight,
+    overscan: virtualizationPreset.value.overscan,
+}))
+
+const crossTraceVirtualizer = useVirtualizer(crossTraceVirtualizerOptions)
+
+const crossTraceVirtualItems = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value) {
+        return []
+    }
+
+    return crossTraceVirtualizer.value.getVirtualItems()
+})
+
+const crossTraceTopPadding = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value || crossTraceVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    return crossTraceVirtualItems.value[0].start
+})
+
+const crossTraceBottomPadding = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value || crossTraceVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    const total = crossTraceVirtualizer.value.getTotalSize()
+    const last = crossTraceVirtualItems.value[crossTraceVirtualItems.value.length - 1]
+
+    return Math.max(0, total - last.end)
+})
+
+const visibleCrossTraceRows = computed(() => {
+    if (!virtualizedTraceRowsEnabled.value) {
+        return crossTraceRows.value
+    }
+
+    return crossTraceVirtualItems.value
+        .map((item) => crossTraceRows.value[item.index])
+        .filter((row): row is CrossTraceRenderSummaryRow => Boolean(row))
+})
 
 function elapsedFromSpans(trace: TraceEntry): number | undefined {
     if (!trace.spans.length) {
@@ -407,7 +510,7 @@ function handleCrossTraceRowClick(componentKey: string) {
                 <div class="trace-viewer__list-header">
                     <span class="trace-viewer__list-title">Traces</span>
                 </div>
-                <div class="trace-viewer__table-wrap tracker-table-wrap">
+                <div ref="traceListScrollRef" class="trace-viewer__table-wrap tracker-table-wrap">
                     <table class="data-table">
                         <thead>
                             <tr>
@@ -418,7 +521,14 @@ function handleCrossTraceRowClick(componentKey: string) {
                         </thead>
                         <tbody>
                             <tr
-                                v-for="trace in filteredTraces"
+                                v-if="virtualizedTraceRowsEnabled && traceListTopPadding > 0"
+                                class="trace-viewer__virtual-spacer-row"
+                                aria-hidden="true"
+                            >
+                                <td colspan="3" :style="{ height: `${traceListTopPadding}px` }"></td>
+                            </tr>
+                            <tr
+                                v-for="trace in visibleTraceRows"
                                 :key="trace.id"
                                 :class="{ 'trace-viewer__trace-row--selected': selectedTrace?.id === trace.id }"
                                 class="trace-viewer__trace-row"
@@ -427,6 +537,13 @@ function handleCrossTraceRowClick(componentKey: string) {
                                 <td class="mono">{{ trace.name }}</td>
                                 <td class="mono">{{ formatDuration(trace.durationMs, trace) }}</td>
                                 <td class="mono">{{ trace.spans.length }}</td>
+                            </tr>
+                            <tr
+                                v-if="virtualizedTraceRowsEnabled && traceListBottomPadding > 0"
+                                class="trace-viewer__virtual-spacer-row"
+                                aria-hidden="true"
+                            >
+                                <td colspan="3" :style="{ height: `${traceListBottomPadding}px` }"></td>
                             </tr>
                             <tr v-if="!filteredTraces.length">
                                 <td colspan="3" class="tracker-empty-cell">
@@ -585,7 +702,7 @@ function handleCrossTraceRowClick(componentKey: string) {
                                         ✕ clear
                                     </span>
                                 </div>
-                                <div v-if="crossTraceSummaryOpen" class="trace-viewer__render-summary-table-wrap">
+                                <div v-if="crossTraceSummaryOpen" ref="crossTraceScrollRef" class="trace-viewer__render-summary-table-wrap">
                                     <div class="trace-viewer__comparison-toolbar">
                                         <button
                                             :class="{ 'trace-viewer__comparison-chip--active': crossTraceOnlyRegressions }"
@@ -647,7 +764,14 @@ function handleCrossTraceRowClick(componentKey: string) {
                                         </thead>
                                         <tbody>
                                             <tr
-                                                v-for="row in crossTraceRows"
+                                                v-if="virtualizedTraceRowsEnabled && crossTraceTopPadding > 0"
+                                                class="trace-viewer__virtual-spacer-row"
+                                                aria-hidden="true"
+                                            >
+                                                <td colspan="7" :style="{ height: `${crossTraceTopPadding}px` }"></td>
+                                            </tr>
+                                            <tr
+                                                v-for="row in visibleCrossTraceRows"
                                                 :key="row.componentKey"
                                                 :class="{
                                                     'trace-viewer__render-summary-row--active':
@@ -668,6 +792,13 @@ function handleCrossTraceRowClick(componentKey: string) {
                                                 </td>
                                                 <td class="mono trace-viewer__col-desktop">{{ formatDuration(row.avgMsPerRender) }}</td>
                                                 <td class="mono">{{ formatDuration(row.totalMs) }}</td>
+                                            </tr>
+                                            <tr
+                                                v-if="virtualizedTraceRowsEnabled && crossTraceBottomPadding > 0"
+                                                class="trace-viewer__virtual-spacer-row"
+                                                aria-hidden="true"
+                                            >
+                                                <td colspan="7" :style="{ height: `${crossTraceBottomPadding}px` }"></td>
                                             </tr>
                                             <tr v-if="!crossTraceRows.length">
                                                 <td colspan="7" class="tracker-empty-cell">No components match the comparison filters.</td>
@@ -836,6 +967,12 @@ function handleCrossTraceRowClick(componentKey: string) {
 .trace-viewer__trace-row--selected {
     background: var(--bg2, var(--bg));
     border-left: 2px solid var(--accent);
+}
+
+.trace-viewer__virtual-spacer-row td {
+    padding: 0;
+    border-bottom: 0;
+    background: transparent;
 }
 
 .trace-viewer__detail {

--- a/client/src/views/TransitionTimeline.vue
+++ b/client/src/views/TransitionTimeline.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
+import { useVirtualizationConfig } from '@observatory-client/composables/useVirtualizationConfig'
+import { useVirtualizationFlags } from '@observatory-client/composables/useVirtualizationFlags'
 import { useResizablePane } from '@observatory-client/composables/useResizablePane'
 import { useObservatoryData } from '@observatory-client/stores/observatory'
 import type { TransitionEntry } from '@observatory/types/snapshot'
@@ -11,6 +14,10 @@ type FilterMode = 'all' | 'cancelled' | 'active' | 'completed'
 const filter = ref<FilterMode>('all')
 const search = ref('')
 const selected = ref<TransitionEntry | null>(null)
+const tableScrollRef = ref<HTMLElement | null>(null)
+
+const { effective: virtualizationFlags } = useVirtualizationFlags()
+const { preset: virtualizationPreset } = useVirtualizationConfig({ rowHeight: 42, overscan: 10 })
 
 const filtered = computed(() => {
     let list = [...entries.value]
@@ -62,6 +69,60 @@ const timelineGeometry = computed(() => {
         left: ((e.startTime - minT) / span) * 100,
         width: (((e.endTime ?? e.startTime + 80) - e.startTime) / span) * 100,
     }))
+})
+
+const virtualizedRowsEnabled = computed(() => virtualizationFlags.value.transitions)
+
+const tableVirtualizerOptions = computed(() => ({
+    count: filtered.value.length,
+    getScrollElement: () => tableScrollRef.value,
+    estimateSize: () => virtualizationPreset.value.rowHeight,
+    overscan: virtualizationPreset.value.overscan,
+}))
+
+const tableVirtualizer = useVirtualizer(tableVirtualizerOptions)
+
+const tableVirtualItems = computed(() => {
+    if (!virtualizedRowsEnabled.value) {
+        return []
+    }
+
+    return tableVirtualizer.value.getVirtualItems()
+})
+
+const topTablePadding = computed(() => {
+    if (!virtualizedRowsEnabled.value || tableVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    return tableVirtualItems.value[0].start
+})
+
+const bottomTablePadding = computed(() => {
+    if (!virtualizedRowsEnabled.value || tableVirtualItems.value.length === 0) {
+        return 0
+    }
+
+    const total = tableVirtualizer.value.getTotalSize()
+    const last = tableVirtualItems.value[tableVirtualItems.value.length - 1]
+
+    return Math.max(0, total - last.end)
+})
+
+const visibleRows = computed(() => {
+    if (!virtualizedRowsEnabled.value) {
+        return filtered.value.map((entry, index) => ({
+            entry,
+            geometry: timelineGeometry.value[index],
+        }))
+    }
+
+    return tableVirtualItems.value
+        .map((item) => ({
+            entry: filtered.value[item.index],
+            geometry: timelineGeometry.value[item.index],
+        }))
+        .filter((row): row is { entry: TransitionEntry; geometry: { left: number; width: number } } => Boolean(row.entry && row.geometry))
 })
 
 function phaseColor(phase: TransitionEntry['phase']): string {
@@ -166,7 +227,7 @@ function directionColor(e: TransitionEntry): string {
         <!-- Main content -->
         <div class="transition-timeline__content tracker-split">
             <!-- Timeline table -->
-            <div class="transition-timeline__table tracker-table-wrap">
+            <div ref="tableScrollRef" class="transition-timeline__table tracker-table-wrap">
                 <table class="data-table">
                     <thead>
                         <tr>
@@ -180,39 +241,54 @@ function directionColor(e: TransitionEntry): string {
                     </thead>
                     <tbody>
                         <tr
-                            v-for="(entry, i) in filtered"
-                            :key="entry.id"
-                            :class="{ selected: selected?.id === entry.id }"
-                            @click="selected = selected?.id === entry.id ? null : entry"
+                            v-if="virtualizedRowsEnabled && topTablePadding > 0"
+                            class="transition-timeline__virtual-spacer-row"
+                            aria-hidden="true"
+                        >
+                            <td colspan="6" :style="{ height: `${topTablePadding}px` }"></td>
+                        </tr>
+                        <tr
+                            v-for="row in visibleRows"
+                            :key="row.entry.id"
+                            :class="{ selected: selected?.id === row.entry.id }"
+                            @click="selected = selected?.id === row.entry.id ? null : row.entry"
                         >
                             <td>
-                                <span class="transition-timeline__name mono">{{ entry.transitionName }}</span>
+                                <span class="transition-timeline__name mono">{{ row.entry.transitionName }}</span>
                             </td>
                             <td>
-                                <span class="transition-timeline__direction mono" :style="{ color: directionColor(entry) }">
-                                    {{ directionLabel(entry) }}
+                                <span class="transition-timeline__direction mono" :style="{ color: directionColor(row.entry) }">
+                                    {{ directionLabel(row.entry) }}
                                 </span>
                             </td>
                             <td>
-                                <span class="badge" :class="phaseBadgeClass(entry.phase)">{{ entry.phase }}</span>
+                                <span class="badge" :class="phaseBadgeClass(row.entry.phase)">{{ row.entry.phase }}</span>
                             </td>
                             <td class="transition-timeline__duration mono">
-                                {{ entry.durationMs !== undefined ? entry.durationMs + 'ms' : '—' }}
+                                {{ row.entry.durationMs !== undefined ? row.entry.durationMs + 'ms' : '—' }}
                             </td>
-                            <td class="transition-timeline__component muted">{{ entry.parentComponent }}</td>
+                            <td class="transition-timeline__component muted">{{ row.entry.parentComponent }}</td>
                             <td class="transition-timeline__bar-cell">
                                 <div class="transition-timeline__bar-track">
                                     <div
                                         class="transition-timeline__bar-fill"
                                         :style="{
-                                            left: timelineGeometry[i]?.left + '%',
-                                            width: Math.max(timelineGeometry[i]?.width ?? 1, 1) + '%',
-                                            background: phaseColor(entry.phase),
-                                            opacity: entry.phase === 'entering' || entry.phase === 'leaving' ? '0.55' : '1',
+                                            left: row.geometry.left + '%',
+                                            width: Math.max(row.geometry.width, 1) + '%',
+                                            background: phaseColor(row.entry.phase),
+                                            opacity: row.entry.phase === 'entering' || row.entry.phase === 'leaving' ? '0.55' : '1',
                                         }"
                                     />
                                 </div>
                             </td>
+                        </tr>
+
+                        <tr
+                            v-if="virtualizedRowsEnabled && bottomTablePadding > 0"
+                            class="transition-timeline__virtual-spacer-row"
+                            aria-hidden="true"
+                        >
+                            <td colspan="6" :style="{ height: `${bottomTablePadding}px` }"></td>
                         </tr>
 
                         <tr v-if="!filtered.length">
@@ -390,6 +466,12 @@ function directionColor(e: TransitionEntry): string {
     min-width: 0;
     border: none;
     border-radius: 0;
+}
+
+.transition-timeline__virtual-spacer-row td {
+    padding: 0;
+    border-bottom: 0;
+    background: transparent;
 }
 
 /* ── Timeline bar ────────────────────────────────────────────────────────── */

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "build": "npm run build:client && nuxt-module-build build",
         "prepack": "npm run build",
         "lint": "eslint .",
-        "format": "prettier --write '**/*.{ts,vue,js,json}' --ignore-path .prettierignore && stylelint '**/*.{css,vue}' --ignore-pattern '**/.nuxt/**' --ignore-pattern '**/.output/**' --ignore-pattern 'coverage/**' --ignore-pattern 'client/dist/**' --ignore-pattern 'scripts/**' --fix && eslint --fix '**/*.{ts,vue,js}' --ignore-pattern '**/.nuxt/**' --ignore-pattern '**/.output/**' --ignore-pattern 'coverage/**' --ignore-pattern 'client/dist/**' --ignore-pattern 'scripts/**' --ignore-pattern 'docs/dist/**'",
+        "format": "prettier --write '**/*.{ts,vue,js,json}' --ignore-path .prettierignore && stylelint '**/*.{css,vue}' --ignore-pattern '**/.nuxt/**' --ignore-pattern '**/.output/**' --ignore-pattern 'coverage/**' --ignore-pattern 'client/dist/**' --ignore-pattern 'scripts/**' --ignore-pattern 'docs/dist/**' --fix && eslint --fix '**/*.{ts,vue,js}' --ignore-pattern '**/.nuxt/**' --ignore-pattern '**/.output/**' --ignore-pattern 'coverage/**' --ignore-pattern 'client/dist/**' --ignore-pattern 'scripts/**' --ignore-pattern 'docs/dist/**'",
         "typecheck": "vue-tsc --noEmit",
         "test": "vitest run",
         "test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
         "@nuxt/schema": "^3.0.0",
         "@pinia/nuxt": "^0.11.3",
         "@playwright/test": "^1.58.2",
+        "@tanstack/vue-virtual": "^3.13.12",
         "@types/babel__generator": "^7.27.0",
         "@types/babel__traverse": "^7.28.0",
         "@types/node": "^25.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2
+      '@tanstack/vue-virtual':
+        specifier: ^3.13.12
+        version: 3.13.23(vue@3.5.30(typescript@5.9.3))
       '@types/babel__generator':
         specifier: ^7.27.0
         version: 7.27.0

--- a/tests/runtime/virtualization-config.test.ts
+++ b/tests/runtime/virtualization-config.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { useVirtualizationConfig, VIRTUALIZATION_DEFAULTS } from '@observatory-client/composables/useVirtualizationConfig'
+
+describe('useVirtualizationConfig', () => {
+    it('exposes default preset values', () => {
+        const { preset } = useVirtualizationConfig()
+
+        expect(preset.value.rowHeight).toBe(VIRTUALIZATION_DEFAULTS.rowHeight)
+        expect(preset.value.overscan).toBe(VIRTUALIZATION_DEFAULTS.overscan)
+    })
+
+    it('clamps row height to a minimum of 20', () => {
+        const { rowHeight, preset } = useVirtualizationConfig({ rowHeight: 8 })
+
+        expect(preset.value.rowHeight).toBe(20)
+
+        rowHeight.value = 18
+        expect(preset.value.rowHeight).toBe(20)
+
+        rowHeight.value = 42
+        expect(preset.value.rowHeight).toBe(42)
+    })
+
+    it('clamps overscan to valid integer range', () => {
+        const { overscan, preset } = useVirtualizationConfig({ overscan: 100 })
+
+        expect(preset.value.overscan).toBe(40)
+
+        overscan.value = 0
+        expect(preset.value.overscan).toBe(2)
+
+        overscan.value = 7.8
+        expect(preset.value.overscan).toBe(8)
+    })
+
+    it('falls back to default overscan for non-finite values', () => {
+        const { overscan, preset } = useVirtualizationConfig({ overscan: Number.NaN })
+
+        expect(preset.value.overscan).toBe(VIRTUALIZATION_DEFAULTS.overscan)
+
+        overscan.value = Number.POSITIVE_INFINITY
+        expect(preset.value.overscan).toBe(VIRTUALIZATION_DEFAULTS.overscan)
+    })
+})

--- a/tests/runtime/virtualization-flags.test.ts
+++ b/tests/runtime/virtualization-flags.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+function setWindowSearch(search: string) {
+    Object.defineProperty(globalThis, 'window', {
+        value: {
+            location: {
+                search,
+            },
+        },
+        configurable: true,
+    })
+}
+
+afterEach(() => {
+    vi.resetModules()
+
+    Object.defineProperty(globalThis, 'window', {
+        value: undefined,
+        configurable: true,
+    })
+})
+
+describe('useVirtualizationFlags', () => {
+    it('uses disabled defaults when no query params are provided', async () => {
+        setWindowSearch('')
+
+        const { useVirtualizationFlags } = await import('@observatory-client/composables/useVirtualizationFlags')
+        const { flags, effective } = useVirtualizationFlags()
+
+        expect(flags.value.enabled).toBe(false)
+        expect(flags.value.fetch).toBe(false)
+        expect(flags.value.heatmap).toBe(false)
+        expect(flags.value.traces).toBe(false)
+        expect(flags.value.composables).toBe(false)
+        expect(flags.value.transitions).toBe(false)
+
+        expect(effective.value.enabled).toBe(false)
+        expect(effective.value.fetch).toBe(false)
+        expect(effective.value.heatmap).toBe(false)
+        expect(effective.value.traces).toBe(false)
+        expect(effective.value.composables).toBe(false)
+        expect(effective.value.transitions).toBe(false)
+    })
+
+    it('applies global and per-screen query overrides', async () => {
+        setWindowSearch('?virt=1&virtFetch=1&virtHeatmap=on&virtTraces=true&virtComposables=1&virtTransitions=1')
+
+        const { useVirtualizationFlags } = await import('@observatory-client/composables/useVirtualizationFlags')
+        const { flags, effective } = useVirtualizationFlags()
+
+        expect(flags.value.enabled).toBe(true)
+        expect(flags.value.fetch).toBe(true)
+        expect(flags.value.heatmap).toBe(true)
+        expect(flags.value.traces).toBe(true)
+        expect(flags.value.composables).toBe(true)
+        expect(flags.value.transitions).toBe(true)
+
+        expect(effective.value.enabled).toBe(true)
+        expect(effective.value.fetch).toBe(true)
+        expect(effective.value.heatmap).toBe(true)
+        expect(effective.value.traces).toBe(true)
+        expect(effective.value.composables).toBe(true)
+        expect(effective.value.transitions).toBe(true)
+    })
+
+    it('keeps per-screen flags disabled in effective state when global is off', async () => {
+        setWindowSearch('?virt=0&virtFetch=1&virtHeatmap=1&virtTraces=1')
+
+        const { useVirtualizationFlags } = await import('@observatory-client/composables/useVirtualizationFlags')
+        const { flags, effective } = useVirtualizationFlags()
+
+        expect(flags.value.fetch).toBe(true)
+        expect(flags.value.heatmap).toBe(true)
+        expect(flags.value.traces).toBe(true)
+
+        expect(effective.value.enabled).toBe(false)
+        expect(effective.value.fetch).toBe(false)
+        expect(effective.value.heatmap).toBe(false)
+        expect(effective.value.traces).toBe(false)
+    })
+
+    it('supports runtime toggles from setters', async () => {
+        setWindowSearch('?virt=1')
+
+        const { useVirtualizationFlags } = await import('@observatory-client/composables/useVirtualizationFlags')
+        const { flags, effective, setAllEnabled, setScreenEnabled } = useVirtualizationFlags()
+
+        setScreenEnabled('fetch', true)
+        setScreenEnabled('heatmap', true)
+
+        expect(flags.value.fetch).toBe(true)
+        expect(flags.value.heatmap).toBe(true)
+        expect(effective.value.fetch).toBe(true)
+        expect(effective.value.heatmap).toBe(true)
+
+        setAllEnabled(false)
+        expect(effective.value.fetch).toBe(false)
+        expect(effective.value.heatmap).toBe(false)
+
+        setAllEnabled(true)
+        expect(effective.value.fetch).toBe(true)
+        expect(effective.value.heatmap).toBe(true)
+    })
+})


### PR DESCRIPTION
This pull request introduces virtualization support for large lists in the Observatory client, improving performance and responsiveness when displaying many items. It adds composable utilities for controlling virtualization features and configuration, integrates them into key views (`ComposableTracker`, `FetchDashboard`, and `RenderHeatmap`), and provides UI controls via query parameters and feature flags. The implementation uses the `@tanstack/vue-virtual` library and allows fine-tuning of row height and overscan settings.

**Virtualization Infrastructure and Feature Flags:**
- Added new composables: `useVirtualizationFlags` for feature flag management (including query param overrides), and `useVirtualizationConfig` for row height/overscan configuration. [[1]](diffhunk://#diff-bbde5e1e7c9c04217b97ed33d0851f748b50ce4c68e19245649c4df94ccdcd1aR1-R129) [[2]](diffhunk://#diff-250897695e5809bb8582639ea0e7c32b017a48e4f808bd4670674d597cde446eR1-R40)
- Initialized virtualization flags early in `App.vue` to ensure correct rollout before rendering views. [[1]](diffhunk://#diff-ecdb84b8617d5229ab0f8338eab22ddbfcfd993c52796b7d05605245e82428f4R10) [[2]](diffhunk://#diff-ecdb84b8617d5229ab0f8338eab22ddbfcfd993c52796b7d05605245e82428f4R26-R28)

**ComposableTracker Virtualization:**
- Integrated virtualization into the composable tracker list: only visible cards are rendered, with dynamic top/bottom spacers and scroll management. [[1]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4R99-R102) [[2]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4R152-R199) [[3]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4L374-R437) [[4]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4R622-R628) [[5]](diffhunk://#diff-1c63bb1f3b0496994da5bb4a1add593c15b62fe38fdba7398c0dd039dc8d48d4R715-R719)

**FetchDashboard Virtualization:**
- Added virtualization for fetch entry tables: renders only visible rows, with support for top/bottom padding rows and scroll container ref. [[1]](diffhunk://#diff-1bf44429ee72830b7ee4ae0c305ea29c172a3866d4cc9953fd910166ee1e0f22R19-R22) [[2]](diffhunk://#diff-1bf44429ee72830b7ee4ae0c305ea29c172a3866d4cc9953fd910166ee1e0f22R58-R103) [[3]](diffhunk://#diff-1bf44429ee72830b7ee4ae0c305ea29c172a3866d4cc9953fd910166ee1e0f22L176-R229) [[4]](diffhunk://#diff-1bf44429ee72830b7ee4ae0c305ea29c172a3866d4cc9953fd910166ee1e0f22L191-R251) [[5]](diffhunk://#diff-1bf44429ee72830b7ee4ae0c305ea29c172a3866d4cc9953fd910166ee1e0f22R284-R290) [[6]](diffhunk://#diff-1bf44429ee72830b7ee4ae0c305ea29c172a3866d4cc9953fd910166ee1e0f22R367-R372)

**RenderHeatmap Virtualization:**
- Introduced virtualization for the heatmap tree view, supporting efficient rendering of large trees. [[1]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R3-R5) [[2]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R218-R221)
- Refactored badge logic for tree nodes into a helper function for reuse and clarity. [[1]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R32-R54) [[2]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7L61-R87)

These changes collectively enable performant rendering of large lists and tables, while allowing controlled rollout and configuration via feature flags and query parameters.