### PR TITLE
Implement virtualization for observer screens with rollout flags - slice #2

### DIFF
--- a/client/src/components/Flamegraph.vue
+++ b/client/src/components/Flamegraph.vue
@@ -291,10 +291,6 @@ const flattenedTree = computed(() => {
     background: var(--tracker-tint-purple-soft, rgb(127 119 221 / 8%));
 }
 
-.flamegraph__row--selected .flamegraph__span-name {
-    color: var(--purple, var(--accent));
-}
-
 .flamegraph__label {
     display: flex;
     align-items: center;
@@ -348,6 +344,10 @@ const flattenedTree = computed(() => {
     text-overflow: ellipsis;
     white-space: nowrap;
     color: var(--text);
+}
+
+.flamegraph__row--selected .flamegraph__span-name {
+    color: var(--purple, var(--accent));
 }
 
 .flamegraph__span-type {

--- a/client/src/components/SpanInspector.vue
+++ b/client/src/components/SpanInspector.vue
@@ -404,7 +404,7 @@ function getSpanColorClass(type: string) {
     overflow: auto;
     max-height: 200px;
     white-space: pre-wrap;
-    word-break: break-word;
+    overflow-wrap: anywhere;
 }
 
 /* Color utilities */

--- a/client/src/composables/composable-search.ts
+++ b/client/src/composables/composable-search.ts
@@ -91,6 +91,9 @@ function valueMatchesQuery(value: unknown, query: string, seen: WeakSet<object>,
 /**
  * Returns true when a composable entry matches the search query.
  * Search scope includes name, file, ref keys, and nested reactive key/value content.
+ * @param {ComposableEntry} entry - Composable entry to inspect.
+ * @param {string} query - Case-insensitive search query.
+ * @returns {boolean} True when the entry matches the query.
  */
 export function matchesComposableEntryQuery(entry: ComposableEntry, query: string): boolean {
     const normalizedQuery = query.trim().toLowerCase()

--- a/client/src/composables/trace-render-aggregation.ts
+++ b/client/src/composables/trace-render-aggregation.ts
@@ -68,7 +68,11 @@ function getComponentIdentity(metadata: SpanMetadata, fallbackId: string): { key
     }
 }
 
-/** Build per-trace render stats grouped by component UID. */
+/**
+ * Build per-trace render stats grouped by component UID.
+ * @param {TraceEntry | undefined} trace - Trace to summarize.
+ * @returns {TraceRenderStatsRow[]} Render metrics grouped by component uid.
+ */
 export function buildRenderSummaryForTrace(trace?: TraceEntry): TraceRenderStatsRow[] {
     if (!trace) {
         return []
@@ -135,7 +139,12 @@ export function buildRenderSummaryForTrace(trace?: TraceEntry): TraceRenderStats
     return rows
 }
 
-/** Build cross-trace render aggregation and comparison against a selected trace. */
+/**
+ * Build cross-trace render aggregation and comparison against a selected trace.
+ * @param {TraceEntry[]} traces - Traces included in the aggregation window.
+ * @param {string | undefined} selectedTraceId - Optional selected trace for baseline comparison.
+ * @returns {CrossTraceRenderSummaryRow[]} Aggregated comparison rows by component identity.
+ */
 export function buildCrossTraceRenderSummary(traces: TraceEntry[], selectedTraceId?: string): CrossTraceRenderSummaryRow[] {
     if (traces.length === 0) {
         return []

--- a/client/src/views/RenderHeatmap.vue
+++ b/client/src/views/RenderHeatmap.vue
@@ -1184,11 +1184,6 @@ function formatTimestamp(t: number): string {
     min-height: 0;
 }
 
-.render-heatmap__roots-panel,
-.render-heatmap__detail-panel {
-    flex-shrink: 0;
-}
-
 .render-heatmap__roots-panel {
     width: 240px;
     margin-right: 12px;
@@ -1205,6 +1200,7 @@ function formatTimestamp(t: number): string {
 
 .render-heatmap__roots-panel,
 .render-heatmap__detail-panel {
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     overflow: auto;

--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -895,14 +895,14 @@ function handleCrossTraceRowClick(componentKey: string) {
     font-family: var(--mono);
 }
 
-.trace-viewer__action-btn:hover:not(:disabled) {
-    background: var(--bg-secondary);
-    color: var(--text);
-}
-
 .trace-viewer__action-btn:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+}
+
+.trace-viewer__action-btn:hover:not(:disabled) {
+    background: var(--bg-secondary);
+    color: var(--text);
 }
 
 .trace-viewer__import-mode-btn {

--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -1,12 +1,12 @@
-@import "tailwindcss";
-@import "@nuxt/ui";
+@import url("tailwindcss");
+@import url("@nuxt/ui");
 
+/* stylelint-disable at-rule-no-unknown */
 @source "../../../content/**/*";
 
 @theme static {
     --container-8xl: 90rem;
     --font-sans: 'Public Sans', sans-serif;
-
     --color-green-50: #EFFDF5;
     --color-green-100: #D9FBE8;
     --color-green-200: #B3F5D1;
@@ -20,6 +20,7 @@
     --color-green-950: #052E16;
     --site-border: #203763;
 }
+/* stylelint-enable at-rule-no-unknown */
 
 :root {
     --ui-container: var(--container-8xl);

--- a/playground/pages/test/fetch-verification.vue
+++ b/playground/pages/test/fetch-verification.vue
@@ -203,11 +203,6 @@ const clearResults = (): void => {
     flex-wrap: wrap;
 }
 
-.fetch-buttons button {
-    padding: 4px 12px;
-    font-size: 12px;
-}
-
 button {
     padding: 8px 16px;
     background-color: #42b883;
@@ -220,6 +215,11 @@ button {
 
 button:hover {
     background-color: #3aa876;
+}
+
+.fetch-buttons button {
+    padding: 4px 12px;
+    font-size: 12px;
 }
 
 .status {

--- a/src/runtime/instrumentation/asyncData.ts
+++ b/src/runtime/instrumentation/asyncData.ts
@@ -7,7 +7,7 @@ interface AsyncDataMeta {
     originalFn?: string
 }
 
-type AnyFn = (...args: any[]) => any
+type AnyFn = (...args: unknown[]) => unknown
 
 function getNormalizedKey(key: unknown) {
     return typeof key === 'string' && key.length > 0 ? key : 'useAsyncData'

--- a/tests/runtime/render-registry.test.ts
+++ b/tests/runtime/render-registry.test.ts
@@ -11,6 +11,12 @@ beforeEach(() => {
 /**
  * Creates and immediately ends a component span in the global traceStore.
  * Used to populate aggregateFromComponentSpans() with test data.
+ * @param {number} uid
+ * @param {'mounted' | 'updated'} lifecycle
+ * @param {{ startTime?: number; durationMs?: number; route?: string }} options
+ * @param {number} [options.startTime]
+ * @param {number} [options.durationMs]
+ * @param {string} [options.route]
  */
 function addComponentSpan(
     uid: number,

--- a/tests/runtime/tracing/tracing.test.ts
+++ b/tests/runtime/tracing/tracing.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { startSpan } from '@observatory/runtime/tracing/tracing'
 import { TraceStore } from '@observatory/runtime/tracing/traceStore'
 

--- a/tests/verification/render-heatmap.spec.ts
+++ b/tests/verification/render-heatmap.spec.ts
@@ -53,6 +53,11 @@ test.describe('Render Heatmap Correctness', () => {
         const componentData = heatmapData.components['TestComponent']
 
         expect(componentData).toBeDefined()
+
+        if (!componentData) {
+            throw new Error('Expected TestComponent to exist in heatmap data')
+        }
+
         expect(componentData.totalRenders).toBe(3)
         expect(componentData.byRoute['/route-a']?.renders).toBe(2)
         expect(componentData.byRoute['/route-b']?.renders).toBe(1)
@@ -69,6 +74,11 @@ test.describe('Render Heatmap Correctness', () => {
         const componentData = heatmapData.components['FastUpdateComponent']
 
         expect(componentData).toBeDefined()
+
+        if (!componentData) {
+            throw new Error('Expected FastUpdateComponent to exist in heatmap data')
+        }
+
         expect(componentData.timeline.length).toBeLessThanOrEqual(100)
 
         // Verify events are in chronological order
@@ -101,6 +111,10 @@ test.describe('Render Heatmap Correctness', () => {
         const componentData = heatmapData.components['HeavyList']
 
         expect(componentData).toBeDefined()
+
+        if (!componentData) {
+            throw new Error('Expected HeavyList to exist in heatmap data')
+        }
 
         const lastEvent = componentData.timeline[componentData.timeline.length - 1]
         expect(lastEvent).toBeDefined()

--- a/tests/verification/trace-viewer.spec.ts
+++ b/tests/verification/trace-viewer.spec.ts
@@ -120,7 +120,7 @@ test.describe('Trace Viewer Correctness', () => {
 
             if (currentTrace && nextTrace) {
                 expect(currentTrace.endTime).toBeLessThanOrEqual(nextTrace.startTime)
-                expect(currentTrace.metadata.route).not.toBe(nextTrace.metadata.route)
+                expect(currentTrace.metadata['route']).not.toBe(nextTrace.metadata['route'])
             }
         }
     })


### PR DESCRIPTION
This pull request includes a mix of CSS adjustments, improved code documentation, and minor code quality fixes across several files. The most significant updates are grouped below.

### CSS and Styling Consistency

* Moved and reordered `.flamegraph__row--selected .flamegraph__span-name` and `.trace-viewer__action-btn:hover:not(:disabled)` rules in `Flamegraph.vue` and `TraceViewer.vue` to improve style specificity and maintainability. [[1]](diffhunk://#diff-86901b4de760c9c294136ab29ecb230390392e1fe795e21d6be9520e0ef16824L294-L297) [[2]](diffhunk://#diff-86901b4de760c9c294136ab29ecb230390392e1fe795e21d6be9520e0ef16824R349-R352) [[3]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24L898-R907)
* Refactored panel flexbox and shrink behavior in `RenderHeatmap.vue` for better layout consistency. [[1]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7L1187-L1191) [[2]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R1203)
* Moved `.fetch-buttons button` CSS block in `fetch-verification.vue` for improved organization. [[1]](diffhunk://#diff-04e5fc7adceff898e4088b892ae3b3f39c389d6f97f028cd9f30eaeaf7a9ded3L206-L210) [[2]](diffhunk://#diff-04e5fc7adceff898e4088b892ae3b3f39c389d6f97f028cd9f30eaeaf7a9ded3R220-R224)
* Updated CSS imports in `docs/assets/main.css` to use `@import url()` and added stylelint rules for better compatibility and linting. [[1]](diffhunk://#diff-5faa7ed0ac8ebbce21018ec0d7e5a2eb04eebbbd7a031e08ecd82f52c1e789d7L1-L9) [[2]](diffhunk://#diff-5faa7ed0ac8ebbce21018ec0d7e5a2eb04eebbbd7a031e08ecd82f52c1e789d7R23)

### Documentation and Code Comments

* Added or expanded JSDoc comments for key functions in `composable-search.ts`, `trace-render-aggregation.ts`, and `render-registry.test.ts` to clarify parameters and return types. [[1]](diffhunk://#diff-e33c0f0410d980dc940b61c0d3c5f99b960e81561446cde39dc835bd97beaea4R94-R96) [[2]](diffhunk://#diff-5e70cf40189cd4b2c470d9f7329f592ca5982a0450dede3101e2b710255ecdbdL71-R75) [[3]](diffhunk://#diff-5e70cf40189cd4b2c470d9f7329f592ca5982a0450dede3101e2b710255ecdbdL138-R147) [[4]](diffhunk://#diff-326787a9106ccec60e0c9dc3cdebd947f0101af931129f9c37644005ab4368beR14-R19)

### Code Quality and Robustness

* Improved type safety by changing `AnyFn` to use `unknown` in `asyncData.ts`.
* Updated word-break handling in `SpanInspector.vue` for more robust text wrapping.
* Added explicit error throws in `render-heatmap.spec.ts` to ensure test failures are clear when expected data is missing. [[1]](diffhunk://#diff-c613585a022e24f96a142fda33ac20ed02c57b9f93f5cf48d76891e1f4e74c7bR56-R60) [[2]](diffhunk://#diff-c613585a022e24f96a142fda33ac20ed02c57b9f93f5cf48d76891e1f4e74c7bR77-R81) [[3]](diffhunk://#diff-c613585a022e24f96a142fda33ac20ed02c57b9f93f5cf48d76891e1f4e74c7bR115-R118)
* Minor test improvements and consistency fixes, such as property access style in `trace-viewer.spec.ts` and removing unused imports in `tracing.test.ts`. [[1]](diffhunk://#diff-a15b98147df9b6eec0db9b9b2fc6e2b04e698b0dc155efd1107b135d04af2e89L123-R123) [[2]](diffhunk://#diff-f5d505c19ebe56bf9baec0f3adb8010d9d8acc6e86a0799d98e6474e93738184L1-R1)

These changes collectively improve the maintainability, clarity, and robustness of the codebase.