### PR TITLE
Enhance trace selection performance with optimized ID lookup

### DIFF
--- a/client/src/views/RenderHeatmap.vue
+++ b/client/src/views/RenderHeatmap.vue
@@ -557,9 +557,11 @@ const filteredRoots = computed(() => {
     return rootNodes.value.filter((root) => isVisibleRoot(root, term))
 })
 
+const filteredRootById = computed(() => new Map(filteredRoots.value.map((node) => [node.id, node])))
+
 const activeRoot = computed(() => {
     if (activeRootId.value) {
-        return filteredRoots.value.find((node) => node.id === activeRootId.value) ?? rootMap.value.get(activeRootId.value) ?? null
+        return filteredRootById.value.get(activeRootId.value) ?? rootMap.value.get(activeRootId.value) ?? null
     }
 
     return filteredRoots.value[0] ?? rootNodes.value[0] ?? null
@@ -691,7 +693,31 @@ const knownRoutes = computed(() => {
     return [...routes].sort()
 })
 
-const activeSelected = computed(() => allComponents.value.find((node) => node.id === activeSelectedId.value) ?? null)
+const activeSelected = computed(() => {
+    if (!activeSelectedId.value) {
+        return null
+    }
+
+    return allComponentsById.value.get(activeSelectedId.value) ?? null
+})
+
+const activeSelectedTimelineRecent = computed(() => {
+    const timeline = activeSelected.value?.timeline ?? []
+
+    if (!timeline.length) {
+        return [] as Array<{ key: string; event: RenderEvent }>
+    }
+
+    const recent: Array<{ key: string; event: RenderEvent }> = []
+    const end = Math.max(timeline.length - 30, 0)
+
+    for (let i = timeline.length - 1; i >= end; i--) {
+        const event = timeline[i]
+        recent.push({ key: `${event.kind}-${event.t}-${i}`, event })
+    }
+
+    return recent
+})
 const totalRenders = computed(() => allComponents.value.reduce((sum, node) => sum + node.rerenders + node.mountCount, 0))
 const hotCount = computed(() => allComponents.value.filter((node) => isHot(node)).length)
 const avgTime = computed(() => {
@@ -1181,16 +1207,14 @@ function formatTimestamp(t: number): string {
                     </div>
                     <div v-if="!activeSelected.timeline.length" class="muted text-sm">no timeline events yet</div>
                     <div v-else class="render-heatmap__timeline-list">
-                        <div
-                            v-for="(event, idx) in [...activeSelected.timeline].reverse().slice(0, 30)"
-                            :key="idx"
-                            class="render-heatmap__timeline-row"
-                        >
-                            <span class="render-heatmap__timeline-kind mono" :class="event.kind">{{ event.kind }}</span>
-                            <span class="render-heatmap__timeline-time mono muted">{{ formatTimestamp(event.t) }}</span>
-                            <span class="render-heatmap__timeline-dur mono">{{ formatMs(event.durationMs) }}</span>
-                            <span v-if="event.triggerKey" class="render-heatmap__timeline-trigger mono muted">{{ event.triggerKey }}</span>
-                            <span class="render-heatmap__timeline-route mono muted">{{ event.route }}</span>
+                        <div v-for="row in activeSelectedTimelineRecent" :key="row.key" class="render-heatmap__timeline-row">
+                            <span class="render-heatmap__timeline-kind mono" :class="row.event.kind">{{ row.event.kind }}</span>
+                            <span class="render-heatmap__timeline-time mono muted">{{ formatTimestamp(row.event.t) }}</span>
+                            <span class="render-heatmap__timeline-dur mono">{{ formatMs(row.event.durationMs) }}</span>
+                            <span v-if="row.event.triggerKey" class="render-heatmap__timeline-trigger mono muted">
+                                {{ row.event.triggerKey }}
+                            </span>
+                            <span class="render-heatmap__timeline-route mono muted">{{ row.event.route }}</span>
                         </div>
                         <div v-if="activeSelected.timeline.length > 30" class="render-heatmap__compact-muted muted text-sm">
                             … {{ activeSelected.timeline.length - 30 }} earlier events

--- a/client/src/views/TraceViewer.vue
+++ b/client/src/views/TraceViewer.vue
@@ -69,6 +69,10 @@ const filteredTraces = computed(() => {
     return applyFilters(sortedTraces.value)
 })
 
+const filteredTraceById = computed(() => {
+    return new Map(filteredTraces.value.map((trace) => [trace.id, trace] as const))
+})
+
 const traceCountLabel = computed(() => {
     const suffix = isImportMode.value ? ' (imported)' : ''
 
@@ -84,7 +88,7 @@ const selectedTrace = computed(() => {
         return filteredTraces.value[0]
     }
 
-    return filteredTraces.value.find((t) => t.id === selectedTraceId.value)
+    return filteredTraceById.value.get(selectedTraceId.value)
 })
 
 const renderSummary = computed<TraceRenderStatsRow[]>(() => buildRenderSummaryForTrace(selectedTrace.value))


### PR DESCRIPTION
This pull request optimizes the way selected and filtered items are retrieved in both `RenderHeatmap.vue` and `TraceViewer.vue` by introducing efficient lookup maps. It also refactors the timeline rendering logic to improve performance and readability, especially when displaying recent events.

**Performance and Lookup Optimizations:**

* [`RenderHeatmap.vue`](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7R560-R564): Introduced `filteredRootById` as a `Map` for efficient lookup of root nodes by ID, and updated `activeRoot` to use this map.
* [`TraceViewer.vue`](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R72-R75): Added `filteredTraceById` as a `Map` for efficient trace lookup by ID, and refactored `selectedTrace` to use this map instead of array search. [[1]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24R72-R75) [[2]](diffhunk://#diff-6d8c54999b0d9d82cf4c5ec5d6684476104ad114634aad39ef92d6b1fb3efa24L87-R91)

**Timeline Rendering Improvements:**

* [`RenderHeatmap.vue`](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7L694-R720): Added `activeSelectedTimelineRecent` computed property to efficiently extract and key the 30 most recent timeline events for the currently active selection. Updated the timeline rendering loop to use this property, improving performance and code clarity. [[1]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7L694-R720) [[2]](diffhunk://#diff-f05166ee7cc1f8b4b7d0ab5977a050a123a236ce407cd6679ab1fee9f57632c7L1184-R1217)