### PR TITLE
Add responsiveness tests for heatmap and trace viewer updates

### DIFF
--- a/tests/verification/render-heatmap.spec.ts
+++ b/tests/verification/render-heatmap.spec.ts
@@ -136,4 +136,20 @@ test.describe('Render Heatmap Correctness', () => {
 
         expect(hasNodeModulesComponent).toBe(false)
     })
+
+    test('should remain responsive after large update bursts', async () => {
+        const updateCount = 120
+
+        for (let i = 0; i < updateCount; i++) {
+            await page.click('[data-testid="force-update"]')
+        }
+
+        const startedAt = Date.now()
+        const heatmapData = await api.getHeatmapData()
+        const elapsedMs = Date.now() - startedAt
+
+        // Guardrail threshold: generous enough to avoid flakiness, strict enough to catch regressions.
+        expect(elapsedMs).toBeLessThan(2000)
+        expect(Object.keys(heatmapData.components).length).toBeGreaterThan(0)
+    })
 })

--- a/tests/verification/trace-viewer.spec.ts
+++ b/tests/verification/trace-viewer.spec.ts
@@ -139,4 +139,21 @@ test.describe('Trace Viewer Correctness', () => {
             expect(foundTypes.has(expectedType)).toBe(true)
         }
     })
+
+    test('should keep trace retrieval responsive with larger trace volumes', async () => {
+        const routeCount = 20
+
+        for (let i = 0; i < routeCount; i++) {
+            await page.click(`[data-testid="nav-to-route-${i % 5}"]`)
+            await page.waitForTimeout(20)
+        }
+
+        const startedAt = Date.now()
+        const traces = await api.getTraces()
+        const elapsedMs = Date.now() - startedAt
+
+        // Guardrail threshold: aims to detect major regressions while staying stable in CI.
+        expect(elapsedMs).toBeLessThan(2000)
+        expect(traces.length).toBeGreaterThanOrEqual(routeCount)
+    })
 })


### PR DESCRIPTION
This pull request adds new end-to-end tests to ensure the application's responsiveness under heavy update and trace retrieval scenarios. These tests are designed to detect performance regressions, especially after large bursts of updates or when handling larger trace volumes.

**Performance and Responsiveness Testing:**

* Added a test to `render-heatmap.spec.ts` that simulates 120 rapid update actions and verifies the heatmap remains responsive, completing data retrieval in under 2 seconds and returning valid results.
* Added a test to `trace-viewer.spec.ts` that simulates navigation to multiple routes, then measures that trace retrieval remains performant (under 2 seconds) and returns at least as many traces as routes visited.