### PR TITLE
Fix import paths in main.css for consistency

### DIFF
--- a/docs/assets/main.css
+++ b/docs/assets/main.css
@@ -1,8 +1,8 @@
-@import url("tailwindcss");
-@import url("@nuxt/ui");
+@import "tailwindcss";
+@import "@nuxt/ui";
 
 /* stylelint-disable at-rule-no-unknown */
-@source "../../../content/**/*";
+@source "../content/**/*";
 
 @theme static {
     --container-8xl: 90rem;


### PR DESCRIPTION
This pull request updates the import paths in the `docs/assets/main.css` file to improve compatibility and fix path resolution issues.

**CSS import path fixes:**

* Changed `@import` statements to use string syntax instead of `url()` for `tailwindcss` and `@nuxt/ui`.
* Updated the `@source` directive path to correctly reference the content directory.