### PR TITLE
Enhance reactivity in provide/inject system and add live value previews

### DIFF
--- a/client/src/views/ProvideInjectGraph.vue
+++ b/client/src/views/ProvideInjectGraph.vue
@@ -380,6 +380,22 @@ const visibleNodes = computed<TreeNodeData[]>(() => {
 
 const visibleLeafCountById = computed(() => buildLeafCountMap(visibleNodes.value))
 
+function findNodeById(roots: TreeNodeData[], id: string): TreeNodeData | null {
+    const stack = [...roots]
+
+    while (stack.length) {
+        const node = stack.pop()!
+
+        if (node.id === id) {
+            return node
+        }
+
+        stack.push(...node.children)
+    }
+
+    return null
+}
+
 watch([visibleNodes, selectedNode], ([currentNodes, currentSelected]) => {
     if (!currentSelected) {
         return
@@ -396,6 +412,15 @@ watch([visibleNodes, selectedNode], ([currentNodes, currentSelected]) => {
 
     if (!ids.has(currentSelected.id)) {
         selectedNode.value = null
+
+        return
+    }
+
+    // Keep details reactive: remap to the latest node instance after snapshots refresh.
+    const latest = findNodeById(currentNodes, currentSelected.id)
+
+    if (latest && latest !== currentSelected) {
+        selectedNode.value = latest
     }
 })
 

--- a/playground/pages/test/provide-inject-verification.vue
+++ b/playground/pages/test/provide-inject-verification.vue
@@ -54,6 +54,34 @@ if (import.meta.dev && import.meta.client) {
             <button data-testid="update-user-profile" @click="updateUserProfile">Update User Profile</button>
         </div>
 
+        <div class="live-preview">
+            <h3>Live Provided Value Preview</h3>
+            <p>
+                <strong>Name:</strong>
+                {{ userProfile.name }}
+            </p>
+            <p>
+                <strong>Theme:</strong>
+                {{ userProfile.settings.theme }}
+            </p>
+            <p>
+                <strong>Notifications:</strong>
+                {{ userProfile.settings.notifications ? 'on' : 'off' }}
+            </p>
+            <p>
+                <strong>Language:</strong>
+                {{ userProfile.settings.language }}
+            </p>
+            <p>
+                <strong>Layout:</strong>
+                {{ userProfile.preferences.layout }}
+            </p>
+            <p>
+                <strong>Items/Page:</strong>
+                {{ userProfile.preferences.itemsPerPage }}
+            </p>
+        </div>
+
         <div class="component-tree">
             <h3>Component Tree Structure</h3>
             <div class="tree">
@@ -147,6 +175,25 @@ button:hover {
     border-radius: 8px;
     background-color: #fafafa;
     margin-bottom: 20px;
+}
+
+.live-preview {
+    margin-bottom: 20px;
+    padding: 14px;
+    border: 1px solid #d7e9dd;
+    border-radius: 8px;
+    background-color: #f4fbf6;
+}
+
+.live-preview h3 {
+    margin: 0 0 8px;
+    color: #2f5a3f;
+}
+
+.live-preview p {
+    margin: 4px 0;
+    color: #2f3d34;
+    font-size: 13px;
 }
 
 .tree {

--- a/src/runtime/composables/provide-inject-registry.ts
+++ b/src/runtime/composables/provide-inject-registry.ts
@@ -36,6 +36,11 @@ export interface InjectEntry {
     line: number
 }
 
+type InternalProvideEntry = ProvideEntry & {
+    /** Live source for reactive values, used to refresh snapshots on read. */
+    __valueSource?: unknown
+}
+
 /**
  * Sets up the provide/inject registry, which tracks all provide/inject calls
  * and their associated metadata (e.g. component name, file, line).
@@ -50,6 +55,7 @@ export function setupProvideInjectRegistry(): {
 } {
     let dirty = true
     let cachedSnapshot = '{"provides":[],"injects":[]}'
+    let hasLiveProvides = false
 
     function markDirty() {
         dirty = true
@@ -57,15 +63,17 @@ export function setupProvideInjectRegistry(): {
 
     // Plain Maps keyed by `${key}:${componentUid}` — O(1) dedup, no Vue reactive overhead.
     // Nothing in the runtime watches these collections, so wrapping them in ref() was wasteful.
-    const provides = new Map<string, ProvideEntry>()
+    const provides = new Map<string, InternalProvideEntry>()
     const injects = new Map<string, InjectEntry>()
 
     function registerProvide(entry: ProvideEntry) {
         // O(1) upsert — replaces an existing entry for the same key + component so
         // re-renders don't accumulate duplicate rows in the graph.
-        provides.set(`${entry.key}:${entry.componentUid}`, entry)
+        const internal = entry as InternalProvideEntry
+        provides.set(`${entry.key}:${entry.componentUid}`, internal)
+        hasLiveProvides = hasLiveProvides || internal.__valueSource !== undefined
         markDirty()
-        emit('provide:register', entry)
+        emit('provide:register', sanitizeProvide(internal))
     }
 
     function registerInject(entry: InjectEntry) {
@@ -77,11 +85,12 @@ export function setupProvideInjectRegistry(): {
     function clear() {
         provides.clear()
         injects.clear()
+        hasLiveProvides = false
         markDirty()
         emit('provide:clear', {})
     }
 
-    function sanitizeProvide(entry: ProvideEntry): ProvideEntry {
+    function sanitizeProvide(entry: InternalProvideEntry): ProvideEntry {
         return {
             key: entry.key,
             componentName: entry.componentName,
@@ -90,9 +99,8 @@ export function setupProvideInjectRegistry(): {
             parentUid: entry.parentUid,
             parentFile: entry.parentFile,
             isReactive: entry.isReactive,
-            // valueSnapshot is already a plain serializable value captured at provide()
-            // time by safeSnapshot() in the shim — no need to deep-clone it again here.
-            valueSnapshot: entry.valueSnapshot,
+            // Reactive values are materialized from their live source on every read.
+            valueSnapshot: entry.__valueSource !== undefined ? safeSnapshot(unref(entry.__valueSource)) : entry.valueSnapshot,
             line: entry.line,
             scope: entry.scope,
             isShadowing: entry.isShadowing,
@@ -122,7 +130,7 @@ export function setupProvideInjectRegistry(): {
     }
 
     function getSnapshot(): string {
-        if (!dirty) {
+        if (!dirty && !hasLiveProvides) {
             return cachedSnapshot
         }
 
@@ -184,6 +192,8 @@ export function __devProvide(key: string | symbol, value: unknown, meta: { file:
     // Detect shadowing: walk up the parent chain to see if any ancestor already provides this key
     const isShadowing = findProvider(keyStr, instance) !== null
 
+    const reactiveValue = isRef(value) || isReactive(value as object)
+
     registry.registerProvide({
         key: keyStr,
         componentName: instance?.type?.__name ?? 'unknown',
@@ -191,12 +201,13 @@ export function __devProvide(key: string | symbol, value: unknown, meta: { file:
         componentUid: instance?.uid ?? -1,
         parentUid: instance?.parent?.uid,
         parentFile: instance?.parent?.type?.__file,
-        isReactive: isRef(value) || isReactive(value as object),
+        isReactive: reactiveValue,
         valueSnapshot: safeSnapshot(unref(value)),
         line: meta.line,
         scope,
         isShadowing,
-    })
+        ...(reactiveValue ? { __valueSource: value } : {}),
+    } as ProvideEntry)
 }
 
 export function __devInject<T>(key: string | symbol, defaultValue: T | undefined, meta: { file: string; line: number }): T | undefined {

--- a/tests/runtime/provide-inject-registry.test.ts
+++ b/tests/runtime/provide-inject-registry.test.ts
@@ -306,6 +306,37 @@ describe('__devProvide + __devInject in component tree', () => {
         expect(reg.getAll().provides).toHaveLength(1)
         expect(reg.getAll().provides[0].isReactive).toBe(true)
     })
+
+    it('__devProvide keeps reactive snapshots fresh after ref mutation', async () => {
+        const { ref } = await import('vue')
+        const reg = setupProvideInjectRegistry()
+        getWindow().__observatory__ = { provideInject: reg }
+
+        const profile = ref({ name: 'Initial', settings: { theme: 'auto' } })
+
+        const Parent = defineComponent({
+            setup() {
+                __devProvide('userProfile', profile, { file: 'Parent.vue', line: 2 })
+                return () => h('div')
+            },
+        })
+
+        const { app } = mountApp(Parent)
+
+        const first = reg.getAll().provides.find((p) => p.key === 'userProfile')
+        expect(first?.valueSnapshot).toEqual({ name: 'Initial', settings: { theme: 'auto' } })
+
+        profile.value = { name: 'Updated', settings: { theme: 'light' } }
+
+        const second = reg.getAll().provides.find((p) => p.key === 'userProfile')
+        expect(second?.valueSnapshot).toEqual({ name: 'Updated', settings: { theme: 'light' } })
+
+        const snap = JSON.parse(reg.getSnapshot()) as { provides: Array<{ key: string; valueSnapshot: unknown }> }
+        const fromSnapshot = snap.provides.find((p) => p.key === 'userProfile')
+        expect(fromSnapshot?.valueSnapshot).toEqual({ name: 'Updated', settings: { theme: 'light' } })
+
+        app.unmount()
+    })
 })
 
 // ── Tests for fixes introduced in the bug-fix pass ────────────────────────


### PR DESCRIPTION
This pull request introduces enhancements to the provide/inject developer tooling, primarily ensuring that reactive provided values always reflect their latest state in snapshots and the UI. It also improves the playground for easier verification and adds a test to validate the new behavior. The most important changes are grouped below:

### Provide/Inject Registry Enhancements

* Modified the provide/inject registry to track the live source of reactive provided values (`__valueSource`) and ensure that `valueSnapshot` is refreshed from the current value on every read, so the UI and snapshots always display up-to-date data. [[1]](diffhunk://#diff-0c93037c8574b3ff3ac37f32cc287c43b411c4f79ce73273575a85155052289cR39-R43) [[2]](diffhunk://#diff-0c93037c8574b3ff3ac37f32cc287c43b411c4f79ce73273575a85155052289cR58-R76) [[3]](diffhunk://#diff-0c93037c8574b3ff3ac37f32cc287c43b411c4f79ce73273575a85155052289cR88-R93) [[4]](diffhunk://#diff-0c93037c8574b3ff3ac37f32cc287c43b411c4f79ce73273575a85155052289cL93-R103) [[5]](diffhunk://#diff-0c93037c8574b3ff3ac37f32cc287c43b411c4f79ce73273575a85155052289cL125-R133) [[6]](diffhunk://#diff-0c93037c8574b3ff3ac37f32cc287c43b411c4f79ce73273575a85155052289cR195-R210)
* Added logic to reset the live-provide tracking flag when the registry is cleared, ensuring consistent behavior across refreshes.

### UI and Playground Improvements

* Added a "Live Provided Value Preview" section to the provide/inject verification playground, allowing users to see real-time updates to provided values as they change.
* Styled the new live preview section for better visual clarity and distinction in the playground UI.

### Graph Selection Consistency

* Improved the `ProvideInjectGraph.vue` component to remap the selected node to the latest instance after a snapshot refresh, preventing stale references and ensuring details remain reactive. [[1]](diffhunk://#diff-3f3090bf631532fa3c7a1a0d5a6914a134c739f015ac1d0f2db27eadd6fa3967R383-R398) [[2]](diffhunk://#diff-3f3090bf631532fa3c7a1a0d5a6914a134c739f015ac1d0f2db27eadd6fa3967R415-R423)

### Testing

* Added a unit test to verify that reactive provided values in the registry update their snapshots after mutation, ensuring the new behavior is robust.